### PR TITLE
Avoid calling blockchain only when having pending transactions

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/service/WalletTransactionService.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/service/WalletTransactionService.java
@@ -18,6 +18,11 @@ public interface WalletTransactionService {
   public List<TransactionDetail> getPendingTransactions();
 
   /**
+   * @return pending transactions count
+   */
+  int countPendingTransactions();
+
+  /**
    * @param address wallet address
    * @param contractAddress contract address to use to filter transactions
    * @param contractMethodName the contract method name to use to filter on

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -155,6 +155,9 @@ public class WalletUtils {
   public static final String                          TRANSACTION_MODIFIED_EVENT               =
                                                                                  "exo.wallet.transaction.modified";
 
+  public static final String                          TRANSACTION_SENT_TO_BLOCKCHAIN_EVENT     =
+                                                                                           "exo.wallet.transaction.sent";
+
   public static final String                          WALLET_ENABLED_EVENT                     = "exo.wallet.enabled";
 
   public static final String                          WALLET_DISABLED_EVENT                    = "exo.wallet.disabled";
@@ -387,7 +390,7 @@ public class WalletUtils {
 
   public static Identity getIdentityByTypeAndId(WalletType type, String remoteId) {
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    return identityManager.getOrCreateIdentity(type.getProviderId(), remoteId, true);
+    return identityManager.getOrCreateIdentity(type.getProviderId(), remoteId);
   }
 
   public static String getSpacePrettyName(String id) {

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletTransactionDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletTransactionDAO.java
@@ -131,6 +131,14 @@ public class WalletTransactionDAO extends GenericDAOJPAImpl<TransactionEntity, L
     return resultList == null ? null : resultList;
   }
 
+  public int countPendingTransactions(long networkId) {
+    TypedQuery<Long> query = getEntityManager().createNamedQuery("WalletTransaction.countPendingTransactions",
+                                                                 Long.class);
+    query.setParameter(NETWORK_ID_PARAM, networkId);
+    Long result = query.getSingleResult();
+    return result == null ? 0 : result.intValue();
+  }
+
   public TransactionEntity getTransactionByHash(String hash) {
     TypedQuery<TransactionEntity> query = getEntityManager().createNamedQuery("WalletTransaction.getTransactionByHash",
                                                                               TransactionEntity.class);

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/TransactionEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/TransactionEntity.java
@@ -19,6 +19,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     @NamedQuery(name = "WalletTransaction.getContractTransactionsWithMethodName", query = "SELECT tx FROM WalletTransaction tx WHERE (tx.contractAddress = :contractAddress OR tx.toAddress = :contractAddress) AND tx.contractMethodName = :methodName ORDER BY tx.createdDate DESC"),
     @NamedQuery(name = "WalletTransaction.getNetworkTransactions", query = "SELECT tx FROM WalletTransaction tx WHERE tx.networkId = :networkId ORDER BY tx.createdDate DESC"),
     @NamedQuery(name = "WalletTransaction.getPendingTransactions", query = "SELECT tx FROM WalletTransaction tx WHERE tx.networkId = :networkId AND tx.isPending = TRUE"),
+    @NamedQuery(name = "WalletTransaction.countPendingTransactions", query = "SELECT count(tx) FROM WalletTransaction tx WHERE tx.networkId = :networkId AND tx.isPending = TRUE"),
     @NamedQuery(name = "WalletTransaction.getTransactionByHash", query = "SELECT tx FROM WalletTransaction tx WHERE tx.hash = :hash"),
     @NamedQuery(name = "WalletTransaction.getMaxUsedNonce", query = "SELECT MAX(tx.nonce) FROM WalletTransaction tx WHERE tx.networkId = :networkId AND tx.fromAddress = :address"),
     @NamedQuery(name = "WalletTransaction.getTransactionsToSend", query = "SELECT tx FROM WalletTransaction tx WHERE tx.networkId = :networkId AND tx.isPending = TRUE AND tx.sentDate = 0 AND tx.rawTransaction IS NOT NULL ORDER BY tx.nonce ASC"),

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
@@ -101,6 +101,11 @@ public class WalletTransactionServiceImpl implements WalletTransactionService {
   }
 
   @Override
+  public int countPendingTransactions() {
+    return transactionStorage.countPendingTransactions(getNetworkId());
+  }
+
+  @Override
   public List<TransactionDetail> getTransactions(String address,
                                                  String contractAddress,
                                                  String contractMethodName,

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
@@ -31,6 +31,10 @@ public class TransactionStorage {
     return fromEntities(transactions);
   }
 
+  public int countPendingTransactions(long networkId) {
+    return walletTransactionDAO.countPendingTransactions(networkId);
+  }
+
   /**
    * @param networkId blockchain network id
    * @return {@link List} of {@link TransactionDetail} not yet sent on

--- a/wallet-services/src/test/java/org/exoplatform/wallet/test/service/WalletTransactionServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/test/service/WalletTransactionServiceTest.java
@@ -344,6 +344,7 @@ public class WalletTransactionServiceTest extends BaseWalletTest {
                                                                   System.currentTimeMillis());
     entitiesToClean.add(transactionDetail);
 
+    assertEquals(1, walletTransactionService.countPendingTransactions());
     pendingTransactions = walletTransactionService.getPendingTransactions();
     assertNotNull(pendingTransactions);
     assertEquals(1, pendingTransactions.size());

--- a/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/listener/TransactionMinedAndUpdatedListener.java
+++ b/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/listener/TransactionMinedAndUpdatedListener.java
@@ -1,0 +1,27 @@
+package org.exoplatform.wallet.blockchain.listener;
+
+import org.exoplatform.services.listener.*;
+import org.exoplatform.wallet.blockchain.service.EthereumClientConnector;
+import org.exoplatform.wallet.model.transaction.TransactionDetail;
+import org.exoplatform.wallet.service.WalletTransactionService;
+
+@Asynchronous
+public class TransactionMinedAndUpdatedListener extends Listener<Object, TransactionDetail> {
+
+  private WalletTransactionService walletTransactionService;
+
+  private EthereumClientConnector  web3jConnector;
+
+  public TransactionMinedAndUpdatedListener(WalletTransactionService walletTransactionService,
+                                            EthereumClientConnector web3jConnector) {
+    this.walletTransactionService = walletTransactionService;
+    this.web3jConnector = web3jConnector;
+  }
+
+  @Override
+  public void onEvent(Event<Object, TransactionDetail> event) throws Exception {
+    if (!this.web3jConnector.isPermanentlyScanBlockchain() && this.walletTransactionService.countPendingTransactions() == 0) {
+      this.web3jConnector.stopListeningToBlockchain();
+    }
+  }
+}

--- a/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/listener/TransactionSentToBlockchainListener.java
+++ b/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/listener/TransactionSentToBlockchainListener.java
@@ -1,0 +1,29 @@
+package org.exoplatform.wallet.blockchain.listener;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.wallet.blockchain.service.EthereumClientConnector;
+import org.exoplatform.wallet.model.transaction.TransactionDetail;
+import org.exoplatform.wallet.service.WalletTransactionService;
+
+public class TransactionSentToBlockchainListener extends Listener<Object, TransactionDetail> {
+
+  private WalletTransactionService walletTransactionService;
+
+  private EthereumClientConnector  web3jConnector;
+
+  public TransactionSentToBlockchainListener(WalletTransactionService walletTransactionService,
+                                 EthereumClientConnector web3jConnector) {
+    this.walletTransactionService = walletTransactionService;
+    this.web3jConnector = web3jConnector;
+  }
+
+  @Override
+  public void onEvent(Event<Object, TransactionDetail> event) throws Exception {
+    if (!this.web3jConnector.isPermanentlyScanBlockchain()
+        && this.walletTransactionService.countPendingTransactions() > 0) {
+      long lastestBlockNumber = this.web3jConnector.getLastestBlockNumber();
+      this.web3jConnector.renewBlockSubscription(lastestBlockNumber);
+    }
+  }
+}

--- a/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/servlet/ServiceLoaderServlet.java
+++ b/wallet-webapps-common/src/main/java/org/exoplatform/wallet/blockchain/servlet/ServiceLoaderServlet.java
@@ -119,6 +119,12 @@ public class ServiceLoaderServlet extends HttpServlet {
       listernerService.addListener(KNOWN_TRANSACTION_MINED_EVENT, new TransactionMinedListener());
       listernerService.addListener(TRANSACTION_MODIFIED_EVENT, new TransactionNotificationListener(container));
       listernerService.addListener(TRANSACTION_MODIFIED_EVENT, new WebSocketTransactionListener());
+      listernerService.addListener(TRANSACTION_MODIFIED_EVENT,
+                                   new TransactionMinedAndUpdatedListener(walletTransactionService,
+                                                                          web3jConnector));
+      listernerService.addListener(TRANSACTION_SENT_TO_BLOCKCHAIN_EVENT,
+                                   new TransactionSentToBlockchainListener(walletTransactionService,
+                                                                           web3jConnector));
       listernerService.addListener(WALLET_MODIFIED_EVENT, new WebSocketWalletListener());
       listernerService.addListener(CONTRACT_MODIFIED_EVENT, new WebSocketContractListener());
 

--- a/wallet-webapps-common/src/test/java/org/exoplatform/wallet/blockchain/test/service/EthereumBlockchainTransactionServiceTest.java
+++ b/wallet-webapps-common/src/test/java/org/exoplatform/wallet/blockchain/test/service/EthereumBlockchainTransactionServiceTest.java
@@ -81,7 +81,7 @@ public class EthereumBlockchainTransactionServiceTest {
     Mockito.when(walletTransactionService.getPendingTransactions()).thenReturn(Collections.singletonList(transactionDetail));
     Mockito.when(walletTransactionService.getTransactionByHash(Matchers.eq(TX_HASH))).thenReturn(transactionDetail);
 
-    // Check pending transaction not sent after MEX_PENDING_DAYS and verify that
+    // Check pending transaction not sent after MAX_PENDING_DAYS and verify that
     // it will be sent again
     blockchainTransactionService.checkPendingTransactions();
 
@@ -97,7 +97,7 @@ public class EthereumBlockchainTransactionServiceTest {
     sentTimestamp = sentTimestamp - ONE_DAY_IN_MS * MAX_TRANSACTION_PENDING_DAYS - 1;
     transactionDetail.setSentTimestamp(sentTimestamp);
 
-    // Check pending transaction not sent after MEX_PENDING_DAYS and verify that
+    // Check pending transaction not sent after MAX_PENDING_DAYS and verify that
     // it will be sent again
     blockchainTransactionService.checkPendingTransactions();
 


### PR DESCRIPTION
This modification will avoid calling blockchain all time and call it only when having more than one transaction marked as pending or sent to blockchain.