### PR TITLE
MAINT-27024 Fix Gas Price computing when user has low ether balance

### DIFF
--- a/wallet-services/src/main/resources/db/changelog/wallet-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-services/src/main/resources/db/changelog/wallet-rdbms.db.changelog-1.0.0.xml
@@ -243,4 +243,8 @@
     </addColumn>
   </changeSet>
 
+  <changeSet author="wallet" id="1.3.0-26">
+    <dropUniqueConstraint tableName="ADDONS_WALLET_TRANSACTION" constraintName="UK_WALLET_TRANSACTION_HASH" />
+  </changeSet>
+
 </databaseChangeLog>

--- a/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/common/WalletAdminOperationModal.vue
+++ b/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/common/WalletAdminOperationModal.vue
@@ -304,7 +304,7 @@ export default {
         })
         .then((estimatedGas) => {
           // Add 10% of estimated gas
-          this.gasEstimation = estimatedGas * 1.1;
+          this.gasEstimation = parseInt(estimatedGas * 1.1);
         })
         .catch((e) => {
           console.debug('Error while estimating gas', e);

--- a/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/contracts/modals/WalletAdminInitializeModal.vue
+++ b/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/contracts/modals/WalletAdminInitializeModal.vue
@@ -320,7 +320,7 @@ export default {
             })
             .then((estimatedGas) => {
               // Add 10% to ensure that the operation doesn't take more than the estimation
-              this.estimatedGas = estimatedGas * 1.1;
+              this.estimatedGas = parseInt(estimatedGas * 1.1);
             })
             .catch((e) => {
               console.debug('Error while estimating gas', e);

--- a/wallet-webapps-common/package.json
+++ b/wallet-webapps-common/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --fix ./src/main/webapp/vue-app/*.js ./src/main/webapp/vue-app/**/*.js ./src/main/webapp/vue-app/**/*.vue",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "build": "webpack --config webpack.prod.js --mode production",
-    "ganache-cli": "ganache-cli --account=0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3,100000000000000000000 --networkId 4452364 -b 30 -g 10000000000 --debug --db ~/.ganache-data"
+    "ganache-cli": "ganache-cli --account=0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3,100000000000000000000 --networkId 4452364 -b 10 -g 60000000000 --debug --db ~/.ganache-data"
   },
   "author": "eXo",
   "license": "LGPL",

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -336,7 +336,7 @@ export default {
             })
             .then((estimatedGas) => {
               // Add 10% to ensure that the operation doesn't take more than the estimation
-              this.estimatedGas = estimatedGas * 1.1;
+              this.estimatedGas = parseInt(estimatedGas * 1.1);
             })
             .catch((e) => {
               console.debug('Error while estimating gas', e);

--- a/wallet-webapps-reward/src/main/webapp/vue-app/components/reward/SendRewardsTab.vue
+++ b/wallet-webapps-reward/src/main/webapp/vue-app/components/reward/SendRewardsTab.vue
@@ -31,7 +31,10 @@
           @input="selectedDateMenu = false" />
       </v-menu>
     </v-card-text>
-    <v-container fluid grid-list-md>
+    <v-container
+      fluid
+      grid-list-md
+      class="border-box-sizing">
       <v-layout
         row
         wrap
@@ -66,7 +69,7 @@
         </v-flex>
       </v-layout>
     </v-container>
-    <v-container>
+    <v-container class="border-box-sizing">
       <v-layout>
         <v-flex md4 xs12>
           <v-switch v-model="displayDisabledUsers" :label="$t('exoplatform.wallet.label.displayDisabledUsers')" />

--- a/wallet-webapps/src/main/webapp/vue-app/components/api/WalletAPIApp.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/api/WalletAPIApp.vue
@@ -206,18 +206,8 @@ export default {
         const gasPriceEther = window.localWeb3.utils.fromWei(String(Number(gasPrice) * Number(network.gasLimit)), 'ether').toString();
 
         if (this.wallet.etherBalance < gasPriceEther) {
-          console.debug(`User can't be charged for transaction fees using parametered gas price. Thus normal gas price will be used`);
-          if (this.wallet.etherBalance < network.normalGasPriceEther) {
-            console.debug(`User can't be charged for transaction fees using normal gas price. Thus min gas price will be used`);
-            if (this.wallet.etherBalance < network.minGasPriceEther) {
-              console.debug(`User can't be charged for transaction fees using minimal gas price. Thus return an error`);
-              document.dispatchEvent(new CustomEvent('exo-wallet-send-tokens-error', {
-                detail : this.$t('exoplatform.wallet.warning.noEnoughFunds')
-              }));
-              return;
-            }
-            gasPrice = network.minGasPrice;
-          }
+          console.debug(`User can't be charged for transaction fees using parametered gas price. Thus gas price will be computed from user ether balance`);
+          gasPrice = parseInt(gasPrice * this.wallet.etherBalance / gasPriceEther);
         }
 
         if (!amount || Number.isNaN(parseFloat(amount)) || !Number.isFinite(amount) || amount <= 0) {


### PR DESCRIPTION
1. When the user has a low ether balance comparing to recommended Transaction Fee (= Recommended Gas Price * Transaction Gas Limit), the used gas price fallback to minimum configured gasPrice. By doing this, the sent transaction can take a lot of time to mine. This change will compute maximum gasPrice that a user can send switch his/her ether balance to make sure that transaction get mined faster.
2. In addition to this change, some UI gliches has been fixed in rewards UI to fix Search field overflow and hide vertical scrollbar displayed on page.
3. Another modification is added to make sure that in certain conditions, the estimated retrieved gas is of type int instead of float by using parseInt.
4. Another change consists of dropping a unique constraint on Transaction Hash due to a problem with MySQL default indexes size that is limited to 64. Knowing that the transaction unicity is managed by Application service, this constraint is not needed anymore to make insertion queries faster and avoid indexing a String column