### PR TITLE
Fix Retrieving wallet state on blockchain

### DIFF
--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletBlockchainStateDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletBlockchainStateDAO.java
@@ -16,13 +16,19 @@
  */
 package org.exoplatform.wallet.dao;
 
+import java.util.List;
+
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.wallet.entity.WalletBlockchainStateEntity;
 
 public class WalletBlockchainStateDAO extends GenericDAOJPAImpl<WalletBlockchainStateEntity, Long> {
+
+  private static final Log LOG = ExoLogger.getLogger(WalletBlockchainStateDAO.class);
 
   public WalletBlockchainStateEntity findByWalletIdAndContract(long walletId, String contractAddress) {
     TypedQuery<WalletBlockchainStateEntity> query =
@@ -31,7 +37,15 @@ public class WalletBlockchainStateDAO extends GenericDAOJPAImpl<WalletBlockchain
     query.setParameter("walletId", walletId);
     query.setParameter("contractAddress", contractAddress);
     try {
-      return query.getSingleResult();
+      List<WalletBlockchainStateEntity> resultList = query.getResultList();
+      if (resultList == null || resultList.isEmpty()) {
+        return null;
+      } else {
+        if (resultList.size() > 1) {
+          LOG.debug("Multiple WalletBlockchainStateEntity was found for wallet with id {}", walletId);
+        }
+        return resultList.get(0);
+      }
     } catch (NoResultException e) {
       return null;
     }

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBlockchainStateEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBlockchainStateEntity.java
@@ -29,7 +29,10 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @DynamicUpdate
 @Table(name = "ADDONS_WALLET_BLOCKCHAIN_STATE")
 @NamedQueries({
-    @NamedQuery(name = "WalletBlockchainState.findByWalletIdAndContract", query = "SELECT wb FROM WalletBlockchainState wb WHERE wb.wallet.id = :walletId AND  wb.contractAddress = :contractAddress"),
+  @NamedQuery(
+      name = "WalletBlockchainState.findByWalletIdAndContract",
+      query = "SELECT wb FROM WalletBlockchainState wb WHERE wb.wallet.id = :walletId AND  wb.contractAddress = :contractAddress ORDER BY wb.id DESC"
+  ),
 })
 public class WalletBlockchainStateEntity implements Serializable {
   private static final long serialVersionUID = -7294965683405044055L;

--- a/wallet-services/src/test/java/org/exoplatform/wallet/test/BaseWalletTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/test/BaseWalletTest.java
@@ -151,6 +151,8 @@ public abstract class BaseWalletTest {
 
     LOG.info("Cleaning {} objects after test finished", entitiesToClean.size());
 
+    walletBlockchainStateDAO.deleteAll();
+
     if (!entitiesToClean.isEmpty()) {
       Iterator<Serializable> iterator = entitiesToClean.iterator();
       while (iterator.hasNext()) {

--- a/wallet-services/src/test/java/org/exoplatform/wallet/test/dao/WalletBlockchainStateDAOTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/test/dao/WalletBlockchainStateDAOTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.wallet.test.dao;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.exoplatform.wallet.dao.WalletAccountDAO;
+import org.exoplatform.wallet.dao.WalletBlockchainStateDAO;
+import org.exoplatform.wallet.entity.WalletBlockchainStateEntity;
+import org.exoplatform.wallet.entity.WalletEntity;
+import org.exoplatform.wallet.model.WalletType;
+import org.exoplatform.wallet.test.BaseWalletTest;
+
+public class WalletBlockchainStateDAOTest extends BaseWalletTest {
+
+  /**
+   * Check that service is instantiated and functional
+   */
+  @Test
+  public void testServiceInstantiated() {
+    WalletBlockchainStateDAO walletBlockchainStateDAO = getService(WalletBlockchainStateDAO.class);
+
+    List<WalletBlockchainStateEntity> allStates = walletBlockchainStateDAO.findAll();
+    assertNotNull("Returned states shouldn't be null", allStates);
+    assertEquals("Returned states list should be empty", 0, allStates.size());
+  }
+
+  /**
+   * Test get list of transactions of a chosen contract
+   */
+  @Test
+  public void testGetContractTransactions() {
+    WalletAccountDAO walletAccountDAO = getService(WalletAccountDAO.class);
+    WalletBlockchainStateDAO walletBlockchainStateDAO = getService(WalletBlockchainStateDAO.class);
+
+    String contractAddress = "0xe9dfec7864af9e581a85ce3987d026be0f509ac9";
+
+    WalletEntity walletEntity = new WalletEntity();
+
+    String address = "0xc76987D43b77C45d51653b6eB110b9174aCCE8fb";
+    walletEntity.setId(1L);
+    walletEntity.setAddress(address);
+    walletEntity.setPassPhrase("passphrase");
+    walletEntity.setType(WalletType.USER);
+    walletEntity = walletAccountDAO.create(walletEntity);
+    entitiesToClean.add(walletEntity);
+
+    WalletBlockchainStateEntity blockchainStateEntity = new WalletBlockchainStateEntity();
+    blockchainStateEntity.setContractAddress(contractAddress);
+    blockchainStateEntity.setWallet(walletEntity);
+    WalletBlockchainStateEntity blockchainStateEntity1 = walletBlockchainStateDAO.create(blockchainStateEntity);
+    entitiesToClean.add(blockchainStateEntity1);
+
+    blockchainStateEntity = new WalletBlockchainStateEntity();
+    blockchainStateEntity.setContractAddress(contractAddress);
+    blockchainStateEntity.setWallet(walletEntity);
+    WalletBlockchainStateEntity blockchainStateEntity2 = walletBlockchainStateDAO.create(blockchainStateEntity);
+    entitiesToClean.add(blockchainStateEntity2);
+
+    blockchainStateEntity = walletBlockchainStateDAO.findByWalletIdAndContract(walletEntity.getId(), contractAddress);
+    assertNotNull("Can't find wallet state", blockchainStateEntity);
+    assertEquals(blockchainStateEntity2.getId(), blockchainStateEntity.getId());
+  }
+
+}


### PR DESCRIPTION
Sometimes, the blockchain state of a wallet is stored twice in two different threads. Knowing that there is no RDBMS unicity constraints, the wallet state can be duplicated. This duplication can't lead to incoherence since it's just a sort of cache of information stored on blockchain. Thus, the last Blockchainstate will be used and updated only (By adding 'ORDER BY id DESC' in request).