### PR TITLE
TASK-46687 : fix load more button

### DIFF
--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -438,8 +438,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       position: fixed;
       bottom: 0;
       background : @white;
-      width: 97%;
-      height: 60px
+      width: 100%;
+      height: 60px ;
+      margin-right: 4% ~'; /** orientation=lt */ ';
+      margin-left: 4% ~'; /** orientation=rt */ ';
     }
   }
 


### PR DESCRIPTION
load more button was displayed  above the scroll since the button 
doesn't belong to the drawer footer it belongs to the transactions-list component 