### PR TITLE
Task-45373: Fix Wallet application name and description are not displayed by their value in space settings interface (#45)

### DIFF
--- a/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
@@ -1,0 +1,2 @@
+SpaceSettings.application.wallet.title=Wallet
+SpaceSettings.application.wallet.description=Space Wallet Portlet


### PR DESCRIPTION
Problem: the Wallet application name and description are not displayed by their values in space settings interface.
How it was solved: by adding the Portlets_en.properties file which will configure the default values of name and description of Wallet app.