### PR TITLE
TASK-47710 : Open send funds drawer when accepting a funds request

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensModal.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensModal.vue
@@ -130,8 +130,8 @@ export default {
 
       if (receiver && notificationId) {
         receiverType = receiverType || 'user';
-        checkFundRequestStatus(notificationId).then((sent) => {
-          this.dialog = !sent;
+        checkFundRequestStatus(notificationId).then(() => {
+          this.openSendTokenDrawer();
           return this.$nextTick(() => {
             if (receiver) {
               this.$refs.sendTokensForm.$refs.autocomplete.selectItem(receiver, receiverType);

--- a/wallet-webapps/src/main/webapp/vue-app/components/WalletApp.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/WalletApp.vue
@@ -268,10 +268,8 @@ export default {
       // Init application
       this.init()
         .then(() => {
-          if (this.$refs.walletSummaryActions) {
-            this.$refs.walletSummaryActions.init(this.isReadOnly);
-          }
-          if (this.$refs && this.$refs.walletSummary) {
+          if (this.$refs.walletSummary) {
+            this.$refs.walletSummary.prepareSendForm();
             this.$refs.walletSummary.loadPendingTransactions();
           }
           this.checkOpenTransaction();

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/Summary.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/Summary.vue
@@ -279,6 +279,9 @@ export default {
     openExchangeDrawer() {
       this.$refs.walletSummaryActions.open();
     },
+    prepareSendForm() {
+      this.$refs.walletSummaryActions.init();
+    },
   },
 };
 </script>

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/SummaryButtons.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/SummaryButtons.vue
@@ -104,7 +104,10 @@ export default {
           if (this.isReadOnly || isReadOnly) {
             throw new Error(this.$t('exoplatform.wallet.warning.walletReadonly'));
           }
-          this.$refs.sendTokensModal.prepareSendForm(parameters.receiver, parameters.receiver_type, parameters.amount, parameters.id);
+          this.open();
+          this.$nextTick(() => {
+            this.$refs.sendTokensModal.prepareSendForm(parameters.receiver, parameters.receiver_type, parameters.amount, parameters.id);
+          });
         }
       }
     },


### PR DESCRIPTION
when accepting a funds request a send funds popup appears.
Since the popup was changed to a drawer, when accepting the request the drawer doesn't open because of the component and the refs have changed