### PR TITLE
Task-48208 : Errors during start about template config

### DIFF
--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProvider.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProvider.java
@@ -48,8 +48,8 @@ public class RewardSuccessTemplateProvider extends TemplateProvider {
     this.templateBuilders.put(PLUGIN_KEY, builder);
 
     setWebTemplatePath("war:/conf/wallet/templates/notification/web/RewardSuccessWebPlugin.gtmpl");
-    setMailTemplatePath("war:/conf/wallet/templates/notification/mail/RewardSuccessWebPlugin.gtmpl");
-    setPushTemplatePath("war:/conf/wallet/templates/notification/push/RewardSuccessWebPlugin.gtmpl");
+    setMailTemplatePath("war:/conf/wallet/templates/notification/mail/RewardSuccessMailPlugin.gtmpl");
+    setPushTemplatePath("war:/conf/wallet/templates/notification/push/RewardSuccessPushPlugin.gtmpl");
   }
 
   @Override


### PR DESCRIPTION
Before this fix, there is an error at startup about loading template DocumentActivity.gtpml :

> WARN  | Failed to read template file: war:/conf/wallet/templates/notification/mail/RewardSuccessWebPlugin.gtmpl. An empty message will be used

This is due to the path in configuration file which is not correct : the template name is RewardSuccessMailPlugin.gtmpl.
By treating this issue, I found that the problem is the same for push notification. I update it to
This change updates the path to use the correct one.