### PR TITLE
TASK-49331 : fixed copy Ethereum Address

### DIFF
--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -879,7 +879,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       width: 30% !important;
     }
     .copyToClipboardInput{
-      width: 0;
+      position: absolute;
+      left: -999em;
     }
     .walletAddressCmp{
       width: 70%;


### PR DESCRIPTION
".select()" cannot select a hidden element: by setting the width of an element to 0, it behaves like a hidden element. 
fixed by changing the position of the element so that it is neither visible nor hidden.