### PR TITLE
Clean up translations.properties

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -21,6 +21,5 @@ baseDir=add-ons/wallet/
 # Files
 WalletNotification.properties=wallet-services/src/main/resources/locale/notification/WalletNotification_en.properties
 Wallet.properties=wallet-services/src/main/resources/locale/addon/Wallet_en.properties
-WalletNavigation.properties=wallet-services/src/main/resources/locale/addon/Wallet_en.properties
 webui_en.properties=wallet-webapps-common/src/main/resources/locale/navigation/portal/global_en.properties
 RewardingGroupNavigation.properties=wallet-webapps-common/src/main/resources/locale/navigation/group/platform/rewarding_en.properties


### PR DESCRIPTION
Actually both Wallet.properties and WalletNavigation.Properties is a duplication for the same Wallet_en.properties file 