### PR TITLE
TASK-5139: fix erroneous value of rewards in user profile

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
@@ -130,14 +130,14 @@ public class RewardReportREST implements ResourceContainer {
   @Path("countRewards")
   @RolesAllowed("users")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Return sum of rewards for current user", httpMethod = "GET", produces = "application/json", response = Response.class, notes = "return sum of rewards per user")
+  @ApiOperation(value = "Return sum of rewards for user", httpMethod = "GET", produces = "application/json", response = Response.class, notes = "return sum of rewards per user")
   @ApiResponses(value = {
           @ApiResponse(code = HTTPStatus.OK, message = "Request fulfilled"),
           @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
           @ApiResponse(code = 500, message = "Internal server error") })
-  public Response countRewards(@Context Request request) {
+  public Response countRewards(@Context Request request, @ApiParam(value = "user id", required = true) @QueryParam("userId") String userId ) {
     try {
-      Double sumRewards = rewardReportService.countRewards(WalletUtils.getCurrentUserId());
+      Double sumRewards = rewardReportService.countRewards(userId);
       EntityTag eTag = new EntityTag(String.valueOf(sumRewards));
       Response.ResponseBuilder builder = request.evaluatePreconditions(eTag);
       if (builder == null) {

--- a/wallet-webapps/src/main/webapp/vue-app/WalletBalanceAPI.js
+++ b/wallet-webapps/src/main/webapp/vue-app/WalletBalanceAPI.js
@@ -27,8 +27,8 @@ export function getWalletAccount() {
   });
 }
 
-export  function getCountRewards() {
-  return fetch('/portal/rest/wallet/api/reward/countRewards', {
+export  function getCountRewards(userId) {
+  return fetch(`/portal/rest/wallet/api/reward/countRewards?userId=${userId}`, {
     method: 'GET',
     credentials: 'include',
     headers: {

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-overview/components/WalletOverview.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-overview/components/WalletOverview.vue
@@ -82,7 +82,7 @@ export default {
   },
   created() {
     this.refresh();
-    getCountRewards().then((resp) => {
+    getCountRewards(eXo.env.portal.profileOwner).then((resp) => {
       this.countReward = resp.sumRewards;
     });
   },


### PR DESCRIPTION
the countRewards method always takes the current user to count the reward so it is displayed in all reward widgets
fixed by getting the profile owner rewards Count