### PR TITLE
53063 :Fix admin wallet initialization state

### DIFF
--- a/wallet-packaging/src/main/assemblies/assembly.xml
+++ b/wallet-packaging/src/main/assemblies/assembly.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- WARs -->
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/webapps</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-webapps-common:war</include>
       </includes>
@@ -35,7 +35,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/webapps</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-webapps:war</include>
       </includes>
@@ -44,7 +44,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/webapps</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-webapps-admin:war</include>
       </includes>
@@ -53,7 +53,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/webapps</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-webapps-reward:war</include>
       </includes>
@@ -63,7 +63,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Libraries -->
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>org.exoplatform.wallet:ert-contract:jar</include>
       </includes>
@@ -72,7 +72,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-api:jar</include>
       </includes>
@@ -81,7 +81,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-services:jar</include>
       </includes>
@@ -90,7 +90,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>${project.groupId}:wallet-reward-services:jar</include>
       </includes>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAccountServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAccountServiceImpl.java
@@ -166,7 +166,8 @@ public class WalletAccountServiceImpl implements WalletAccountService, ExoWallet
         if (!StringUtils.equalsIgnoreCase(wallet.getInitializationState(), WalletState.INITIALIZED.name()) &&
             !StringUtils.equalsIgnoreCase(wallet.getInitializationState(), WalletState.PENDING.name()) &&
             !StringUtils.equalsIgnoreCase(wallet.getInitializationState(), WalletState.DENIED.name())
-            && wallet.getIsInitialized() != null && wallet.getIsInitialized()) {
+            && ((wallet.getIsInitialized() != null && wallet.getIsInitialized())
+                || (wallet.getEtherBalance() > 0 && wallet.getTokenBalance() > 0))) { // if wallet was sent cryptos & tokens from outside and its state is NEW, we set it to initialized
           wallet.setInitializationState(WalletState.INITIALIZED.name());
           setInitializationStatus(wallet.getAddress(), WalletState.INITIALIZED);
         }


### PR DESCRIPTION
Admin wallet is created with the WalletState New, this state is never changed. Other wallet state is changed when they are sent tokens and gas fees. This prevents Gas price detector job from running and we can not get frequent gas price updates.
The fix changes the state of the Admin wallet once it has received Tokens & Gas fees. the fix also updates the packaging to put jars in Lib folder and wars in webapps folder