### PR TITLE
TASK-53347 Upgrade to Tomcat 9

### DIFF
--- a/wallet-webapps-common/pom.xml
+++ b/wallet-webapps-common/pom.xml
@@ -161,6 +161,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependency>
     <!-- Test dependencies -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Prior to this change, the slf4j-api jar was bundled in wallet-common while it's already shipped in Parent ClassLoader which causes an exception. This commit will change the scope of slf4j-api to avoid bundling it inside the WAR/WEB-INF/lib.