### PR TITLE
Fix #181 Avoid using single instance of DecimalFormat

### DIFF
--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -24,6 +24,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </parent>
   <artifactId>wallet-api</artifactId>
   <name>eXo Add-on:: Wallet - API</name>
+  <properties>
+    <exo.test.coverage.ratio>0.03</exo.test.coverage.ratio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.exoplatform.ws</groupId>
@@ -58,6 +61,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.math.*;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -270,12 +269,6 @@ public class WalletUtils {
   public static final String                          OPERATION_FILTER_CONTRACT_TRANSACTIONS   = "eth_getLogs";
 
   public static final String                          OPERATION_SEND_TRANSACTION               = "eth_sendRawTransaction";
-
-  public static final DecimalFormat                   SIMPLIFIED_WALLET_BALANCE                = new DecimalFormat("#.##");
-
-  static {
-    SIMPLIFIED_WALLET_BALANCE.setRoundingMode(RoundingMode.DOWN);
-  }
 
   public static final ArgumentLiteral<Wallet>         FUNDS_REQUEST_SENDER_DETAIL_PARAMETER    =
                                                                                             new ArgumentLiteral<>(Wallet.class,
@@ -936,8 +929,26 @@ public class WalletUtils {
     return CommonsUtils.getService(SpaceService.class);
   }
 
-  public static final String formatBalance(double balance) {
-    return SIMPLIFIED_WALLET_BALANCE.format(balance);
+  /**
+   * Format Wallet Balance amount in currency format, without currency symbol
+   * and switch user locale.
+   * 
+   * @param balance amount to format
+   * @param locale designated locale to display balance
+   * @param simplified if true, the fractions will be ignored when the balance
+   *          is greater than 100.
+   * @return formatted balance in user locale
+   */
+  public static final String formatBalance(double balance, Locale locale, boolean simplified) {
+    // Avoid to display fractions when the amount of balance is big
+    if (simplified && balance > 100) {
+      balance = Math.floor(balance);
+    }
+    NumberFormat decimalFormat = NumberFormat.getNumberInstance(locale);
+    decimalFormat.setMaximumFractionDigits(2);
+    decimalFormat.setMinimumFractionDigits(0);
+    decimalFormat.setRoundingMode(RoundingMode.FLOOR);
+    return decimalFormat.format(balance).trim();
   }
 
 }

--- a/wallet-api/src/test/java/org/exoplatform/wallet/utils/WalletUtilsTest.java
+++ b/wallet-api/src/test/java/org/exoplatform/wallet/utils/WalletUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.wallet.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+public class WalletUtilsTest {
+
+  @Test
+  public void testFormatBalance() {
+    assertEquals("0", WalletUtils.formatBalance(0.0000001d, Locale.FRENCH, true));
+    assertEquals("0", WalletUtils.formatBalance(0.0000001d, Locale.ENGLISH, true));
+    assertEquals("0,01", WalletUtils.formatBalance(0.01d, Locale.FRENCH, true));
+    assertEquals("0.1", WalletUtils.formatBalance(0.1d, Locale.ENGLISH, true));
+    assertEquals("2 222 222 222 222", WalletUtils.formatBalance(2222222222222.0000001d, Locale.FRENCH, true));
+    assertEquals("2,222,222,222,222", WalletUtils.formatBalance(2222222222222.0000001d, Locale.ENGLISH, true));
+    assertEquals("222 222 222", WalletUtils.formatBalance(222222222.0500001d, Locale.FRENCH, true));
+    assertEquals("222,222,222", WalletUtils.formatBalance(222222222.5000001d, Locale.ENGLISH, true));
+    assertEquals("222 222 222,05", WalletUtils.formatBalance(222222222.0500001d, Locale.FRENCH, false));
+    assertEquals("222,222,222.5", WalletUtils.formatBalance(222222222.5000001d, Locale.ENGLISH, false));
+  }
+
+}

--- a/wallet-webapps/src/main/webapp/WEB-INF/jsp/walletBalance.jsp
+++ b/wallet-webapps/src/main/webapp/WEB-INF/jsp/walletBalance.jsp
@@ -30,8 +30,7 @@
   String symbol = globalSettings == null || globalSettings.getContractDetail() == null ? "" : globalSettings.getContractDetail().getSymbol();
   Wallet wallet = ExoContainerContext.getService(WalletAccountService.class).getWalletByTypeAndId(WalletType.USER.getId(), request.getRemoteUser(), request.getRemoteUser());
   double balance = (wallet == null || wallet.getTokenBalance() == null || wallet.getInitializationState() == "DELETED") ? 0d : wallet.getTokenBalance();
-  String balanceFixed = balance > 100 ? String.valueOf((int) balance)
-                                        : WalletUtils.formatBalance(balance);
+  String balanceFixed = WalletUtils.formatBalance(balance, request.getLocale(), true);
 %>
 <div class="VuetifyApp">
   <div data-app="true"


### PR DESCRIPTION
Since DecimalFormat isn't thread safe, this fix will instantiate a new NumberFormat for each call. Additionally, this will take care of user locale for number formatting.
