### PR TITLE
53913: remove the usage of Gas Price chooser

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -54,12 +54,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 $emit('receiver-selected', $event);
               " />
             <p class="amountLabel mb-0 mt-2"> {{ $t('exoplatform.wallet.label.amount') }} </p>
-            <wallet-reward-gas-price-choice
-              :wallet="wallet"
-              :estimated-fee="transactionFeeString"
-              :slider="!!transaction"
-              :min-gas-price="transaction && transaction.gasPrice"
-              @changed="gasPrice = $event" />
             <v-text-field
               v-model.number="amount"
               ref="amount"


### PR DESCRIPTION
Currently, when sending transactions between users, they use the max Gas price. 
This is caused by the existence of the component used to choose the gas price for transactions and which takes automatically the maximum gas price.
The fix will remove it from the form of sending tokens (it is already hidden inside the form) until we decide if functionally it is needed for users.