### PR TITLE
Task-55107: Fix creation metamask account

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -70,10 +70,11 @@
             <v-list-item-content>
               <v-list-item-subtitle
                 class="text-sub-title pl-1">
-                <span class="mr-3 useMetamask">{{ $t('exoplatform.wallet.settings.metamaskInstallation') }}</span><a
-                  :href="linkMetamask"
+                <span class="mr-3 useMetamask">{{ $t('exoplatform.wallet.settings.metamaskInstallation') }}</span>
+                <a
+                  :href="metamaskInstallLink"
                   target="_blank"
-                  rel="noopener nofollow">{{ linkMetamask }}</a>
+                  rel="noopener nofollow">{{ metamaskInstallLink }}</a>
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
@@ -90,8 +91,7 @@ export default {
     displayDetails: false,
     wallet: null,
     from: '',
-    useMetamask: false,
-    linkMetamask: 'https://metamask.io/'
+    useMetamask: false
   }),
   computed: {
     isSpace(){
@@ -103,6 +103,17 @@ export default {
     isMetamaskInstalled(){
       return  window.ethereum && window.ethereum.isMetaMask;
     },
+    isMobile() {
+      return this.$vuetify.breakpoint.smAndDown;
+    },
+    currentSiteLink() {
+      return `${window.location.host}${window.location.pathname}`;
+    },
+    metamaskInstallLink() {
+      return this.isMobile
+        && `https://metamask.app.link/dapp/${this.currentSiteLink}`
+        || 'https://metamask.io/';
+    }
 
   },
   created() {

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -57,14 +57,6 @@
                   {{ $t('exoplatform.wallet.settings.useMetamask') }}
                 </div>
               </v-list-item-title>
-              <v-list-item-subtitle
-                class="text-sub-title pl-1 my-3"
-                v-if="!isMetamaskInstalled">
-                <span class="mr-3 useMetamask">{{ $t('exoplatform.wallet.settings.metamaskInstallation') }}</span><a
-                  :href="linkMetamask"
-                  target="_blank"
-                  rel="noopener nofollow">{{ linkMetamask }}</a>
-              </v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-action>
               <v-switch
@@ -73,6 +65,18 @@
                 @click="connectToMetamask"
                 v-model="useMetamask" />
             </v-list-item-action>
+          </v-list-item>
+          <v-list-item class="mt-n2" v-if="!isMetamaskInstalled">
+            <v-list-item-content>
+              <v-list-item-subtitle
+                class="text-sub-title pl-1"
+                >
+                <span class="mr-3 useMetamask">{{ $t('exoplatform.wallet.settings.metamaskInstallation') }}</span><a
+                  :href="linkMetamask"
+                  target="_blank"
+                  rel="noopener nofollow">{{ linkMetamask }}</a>
+              </v-list-item-subtitle>
+            </v-list-item-content>
           </v-list-item>
         </v-list>
       </v-card>

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -69,8 +69,7 @@
           <v-list-item class="mt-n2" v-if="!isMetamaskInstalled">
             <v-list-item-content>
               <v-list-item-subtitle
-                class="text-sub-title pl-1"
-                >
+                class="text-sub-title pl-1">
                 <span class="mr-3 useMetamask">{{ $t('exoplatform.wallet.settings.metamaskInstallation') }}</span><a
                   :href="linkMetamask"
                   target="_blank"


### PR DESCRIPTION
When opening the wallet settings, in the case of the uninstalled Metamask addon, the switch is aligned with the item list "Use Metamask" and the installation link. To solve this problem, another item list has been added, the "Use Metamask" option and the switch are combined in one item list and the Metamask installation link is in another item list.