### PR TITLE
Task-55351: Switch to Meeds without a previously created Meeds wallet

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettingsMetamask.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettingsMetamask.vue
@@ -100,6 +100,12 @@ export default {
     generatedToken() {
       return this.$root.generatedToken;
     },
+    isEmptyPassphrase() {
+      return this.walletSettings.wallet.passPhrase === null;
+    },
+    isDeleted() {
+      return this.walletSettings.wallet.initializationState === 'DELETED';
+    }
   },
   watch: {
     walletSettings: {
@@ -127,6 +133,13 @@ export default {
         this.connectToMetamask();
       } else {
         this.resetMetamask();
+        if (this.isEmptyPassphrase || this.isDeleted) {
+          if (this.walletSettings.wallet.type === 'user') {
+            return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/wallet`;
+          } else {
+            return window.location.href =  `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/SpaceWallet`;
+          }
+        }
       }
     },
     resetMetamask() {

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/Summary.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/Summary.vue
@@ -223,7 +223,7 @@ export default {
       this.$refs.walletSummaryActions.open();
     },
     prepareSendForm() {
-      this.$refs.walletSummaryActions.init();
+      this.$refs.walletSummaryActions?.init();
     },
   },
 };


### PR DESCRIPTION
when switching off the use metamask, without a previously created Meeds wallet, the connected user will be redirected to the creation of the Meeds wallet