### PR TITLE
TASK-56288 : fix automatic scroll to wallet settings

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -93,7 +93,7 @@ export default {
     }
   },
   mounted(){
-    if (window.location.href.includes('toWalletSetting')) {
+    if (window.location.href.includes('walletSetting')) {
       window.location.hash='#walletSettingsApp';
       return window.location.href;
     }

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -92,6 +92,12 @@ export default {
         .finally(() => this.$root.$applicationLoaded());
     }
   },
+    mounted(){
+    if (window.location.href.includes('/settings?from=walletApp&id') || window.location.href.includes('/settings?from=space&id')) {
+      window.location.hash='#walletSettingsApp';
+      return window.location.href;
+    }
+  },
   methods: {
     checkWalletInstalled() {
       this.displayed = false;

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -93,7 +93,7 @@ export default {
     }
   },
     mounted(){
-    if (window.location.href.includes('/settings?from=walletApp&id') || window.location.href.includes('/settings?from=space&id')) {
+    if (window.location.href.includes('toWalletSetting')) {
       window.location.hash='#walletSettingsApp';
       return window.location.href;
     }

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -92,7 +92,7 @@ export default {
         .finally(() => this.$root.$applicationLoaded());
     }
   },
-    mounted(){
+  mounted(){
     if (window.location.href.includes('toWalletSetting')) {
       window.location.hash='#walletSettingsApp';
       return window.location.href;

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
@@ -55,7 +55,7 @@ export default {
   methods: {
     openSettings() {
       if (this.wallet.type === 'space'){
-        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?toWalletSetting`;
+        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?walletSetting`;
       } else {
         return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?toWalletSetting`;
       }

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
@@ -57,7 +57,7 @@ export default {
       if (this.wallet.type === 'space'){
         return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?walletSetting`;
       } else {
-        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?toWalletSetting`;
+        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?walletSetting`;
       }
     }
   }

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
@@ -55,9 +55,9 @@ export default {
   methods: {
     openSettings() {
       if (this.wallet.type === 'space'){
-        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?from=space&id=${this.wallet.id}&type=${this.wallet.type}`;
+        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?toWalletSetting`;
       } else {
-        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?from=walletApp&id=${this.wallet.id}&type=${this.wallet.type}`;
+        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?toWalletSetting`;
       }
     }
   }


### PR DESCRIPTION
No more scrolling down to wallet settings when opening user settings. 
so added a window.location.hash parse to the extension registry wallet when it's mounted to add an anchor to the href and scroll down to the wallet whenever it's loaded . 