### PR TITLE
TASK-55733: Fix Technical label when hovering on wallet address and QRCode from settings page.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </parent>
   <groupId>org.exoplatform.addons.wallet</groupId>
   <artifactId>wallet</artifactId>
-  <version>2.4.x-SNAPSHOT</version>
+  <version>2.4.x-meedsv2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Wallet Add-on</name>
   <description>eXo Wallet Add-on</description>
@@ -49,9 +49,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.social.version>6.4.x-meedsv2-SNAPSHOT</org.exoplatform.social.version>
     <org.exoplatform.wallet.ert-contract.version>1.3.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
-    <org.exoplatform.platform-ui.version>6.4.x-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <org.exoplatform.platform-ui.version>6.4.x-meedsv2-SNAPSHOT</org.exoplatform.platform-ui.version>
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>

--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-api</artifactId>
   <name>eXo Add-on:: Wallet - API</name>

--- a/wallet-packaging/pom.xml
+++ b/wallet-packaging/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-packaging</artifactId>
   <packaging>pom</packaging>

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-reward-services</artifactId>
   <name>eXo Add-on:: Wallet - Reward Services</name>

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-services</artifactId>
   <name>eXo Add-on:: Wallet - Services</name>

--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -299,6 +299,7 @@ exoplatform.wallet.label.sentDate=Sent date
 exoplatform.wallet.label.sendingAttemptCount=Sending attempts
 exoplatform.wallet.label.noRecentTransactions=No recent transactions
 exoplatform.wallet.label.openOnEtherscan=Open in Blockchain Explorer
+exoplatform.wallet.label.copyAddress=Copy Address
 exoplatform.wallet.label.editAddressLabel=Edit label
 exoplatform.wallet.label.moreOptions=More options
 exoplatform.wallet.label.period=Period

--- a/wallet-webapps-admin/pom.xml
+++ b/wallet-webapps-admin/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-webapps-admin</artifactId>
   <packaging>war</packaging>

--- a/wallet-webapps-common/pom.xml
+++ b/wallet-webapps-common/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-webapps-common</artifactId>
   <packaging>war</packaging>

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletAddress.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletAddress.vue
@@ -19,7 +19,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <v-btn
       v-if="allowCopy"
       id="copy"
-      title="Copy address"
+      :title="$t('exoplatform.wallet.label.copyAddress')"
       class="ms-0 me-0 mb-0 mt-0"
       icon
       small

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletSetup.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletSetup.vue
@@ -126,7 +126,7 @@ export default {
       return this.wallet && this.wallet.provider === 'INTERNAL_WALLET' && !this.loading && this.walletAddress && !this.browserWalletExists && this.isReadOnly && (!this.isSpace || this.isSpaceAdministrator);
     },
     displayWalletBackup() {
-      return !this.loading && !this.isAdministration && this.walletAddress && this.browserWalletExists && !this.backedUp && this.initializationState !== 'DELETED';
+      return !this.loading && !this.isAdministration && this.walletAddress && this.browserWalletExists && !this.backedUp && this.initializationState !== 'DELETED' && (this.wallet && this.wallet.provider === 'INTERNAL_WALLET');
     },
     displayWalletBrowserSetup() {
       return this.displayWalletSetup && (this.wallet && !this.wallet.address ||  this.initializationState === 'DELETED');

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -92,6 +92,12 @@ export default {
         .finally(() => this.$root.$applicationLoaded());
     }
   },
+  mounted(){
+    if (window.location.href.includes('walletSetting')) {
+      window.location.hash='#walletSettingsApp';
+      return window.location.href;
+    }
+  },
   methods: {
     checkWalletInstalled() {
       this.displayed = false;

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/main.js
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/main.js
@@ -32,7 +32,7 @@ Vue.use(WalletCommon);
 const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Portlets-${lang}.json`;
+const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.Wallet-${lang}.json`;
 
 const appId = 'walletSettingsApp';
 

--- a/wallet-webapps-reward/pom.xml
+++ b/wallet-webapps-reward/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-webapps-reward</artifactId>
   <packaging>war</packaging>

--- a/wallet-webapps/pom.xml
+++ b/wallet-webapps/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.wallet</groupId>
     <artifactId>wallet</artifactId>
-    <version>2.4.x-SNAPSHOT</version>
+    <version>2.4.x-meedsv2-SNAPSHOT</version>
   </parent>
   <artifactId>wallet-webapps</artifactId>
   <packaging>war</packaging>

--- a/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/wallet-app/ToolbarMenu.vue
@@ -55,9 +55,9 @@ export default {
   methods: {
     openSettings() {
       if (this.wallet.type === 'space'){
-        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?from=space&id=${this.wallet.id}&type=${this.wallet.type}`;
+        return window.location.href = `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/settings?walletSetting`;
       } else {
-        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?from=walletApp&id=${this.wallet.id}&type=${this.wallet.type}`;
+        return window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/settings?walletSetting`;
       }
     }
   }


### PR DESCRIPTION
The i18n configuration in the wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/main.js was consuming 'locale/portlet/Portlets_en.properties' instead of 'locale/addon/Wallet_en.properties' until fix has been made, and the button copy in the wallet address was showing a static message 'Copy Address' until a technical label named 'exoplatform.wallet.label.copyAddress' has been added to the 'locale/addon/Wallet_en.properties' .