### PR TITLE
TASK-55462: fix transaction history list

### DIFF
--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
@@ -174,7 +174,7 @@ public class TransactionStorage {
    List <TransactionEntity> filteredTransactions = new ArrayList<>();
     for(TransactionEntity transaction : transactions) {
       TransactionEntity transactionDetail = filterTransactions.get(transaction.getNonce());
-      if(transactionDetail == null || (transaction.isSuccess() || (!transaction.isSuccess() && !transactionDetail.isSuccess() && transactionDetail.getSentDate() < transaction.getSentDate()))) {
+      if(transactionDetail == null || !transactionDetail.getFromAddress().equals(transaction.getFromAddress()) && (transaction.isSuccess() || (!transaction.isSuccess() && !transactionDetail.isSuccess() && transactionDetail.getSentDate() < transaction.getSentDate()))) {
         filterTransactions.put(transaction.getNonce(), transaction);
         filteredTransactions.add(transaction);
       }

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/TransactionStorage.java
@@ -171,13 +171,15 @@ public class TransactionStorage {
                                                                                       administration);
     // filter transactions having same Nonce and keep last ones
     Map<Long, TransactionEntity> filterTransactions = new HashMap<>();
+   List <TransactionEntity> filteredTransactions = new ArrayList<>();
     for(TransactionEntity transaction : transactions) {
       TransactionEntity transactionDetail = filterTransactions.get(transaction.getNonce());
       if(transactionDetail == null || (transaction.isSuccess() || (!transaction.isSuccess() && !transactionDetail.isSuccess() && transactionDetail.getSentDate() < transaction.getSentDate()))) {
         filterTransactions.put(transaction.getNonce(), transaction);
+        filteredTransactions.add(transaction);
       }
     }
-    return new ArrayList<>(filterTransactions.values());
+    return filteredTransactions;
   }
 
   /**

--- a/wallet-services/src/test/java/org/exoplatform/wallet/test/storage/TransactionStorageTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/test/storage/TransactionStorageTest.java
@@ -203,6 +203,99 @@ public class TransactionStorageTest extends BaseWalletTest {
                                                             onlyPending,
                                                             includeAdministrationTransactions);
     assertEquals("Returned wallet transactions list count is not coherent", 10, transactions.size());
+
+    // duplicate already created transactions
+    // Transactions are duplicated with duplication of the nonce
+    generateTransactions(firstAddress, contractAddress, contractMethodName);
+
+    //retest the same cases with duplicated transactions and asserts that returns the same values
+    //when 2 transaction from the same address having the same nonce one of them must be ignored
+
+    // Search all transactions where a wallet is receiver, sender delegator
+     includeAdministrationTransactions = true;
+     onlyPending = false;
+   transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            null,
+            null,
+            null,
+            0,
+            onlyPending,
+            includeAdministrationTransactions);
+
+    assertNotNull("Returned transactions list is null", transactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 60, transactions.size());
+
+    // Test pagination
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            null,
+            null,
+            null,
+            20,
+            onlyPending,
+            includeAdministrationTransactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 20, transactions.size());
+
+    // Filter on contract address
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            contractAddress,
+            null,
+            null,
+            0,
+            onlyPending,
+            includeAdministrationTransactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 30, transactions.size());
+
+    // Filter on contract method name
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            contractAddress,
+            contractMethodName,
+            null,
+            0,
+            onlyPending,
+            includeAdministrationTransactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 10, transactions.size());
+
+    // Filter on only pending transactions
+    onlyPending = true;
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            contractAddress,
+            contractMethodName,
+            null,
+            0,
+            onlyPending,
+            includeAdministrationTransactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 10, transactions.size());
+
+    oldestTransactionHash = transactionHashList.get(0);
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            null,
+            null,
+            oldestTransactionHash,
+            10,
+            false,
+            true);
+    assertEquals("Returned wallet transactions list should include all transactions, even if limit = 10, the selected hash must be included in result",
+            60,
+            transactions.size());
+
+    // Filter on only pending transactions
+    includeAdministrationTransactions = false;
+    transactions = transactionStorage.getWalletTransactions(1,
+            firstAddress,
+            contractAddress,
+            contractMethodName,
+            null,
+            0,
+            onlyPending,
+            includeAdministrationTransactions);
+    assertEquals("Returned wallet transactions list count is not coherent", 10, transactions.size());
+
   }
 
   /**

--- a/wallet-webapps/src/main/webapp/vue-app/components/WalletApp.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/components/WalletApp.vue
@@ -218,6 +218,7 @@ export default {
         setTimeout(() => {
           thiss.seeAccountDetailsPermanent = true;
         }, 200);
+        this.$refs.accountDetail.open();
       } else {
         $('body').removeClass('hide-scroll');
 
@@ -396,6 +397,7 @@ export default {
         );
         if (this.walletAddress && this.contractDetails && parameters && parameters.hash) {
           this.openAccountDetail(null, parameters.hash);
+          window.history.replaceState('', window.document.title, window.location.href.split('?')[0]);
         }
       }
     },


### PR DESCRIPTION
when retrieving the transactions list it filters it with the nonce
 so when filtring the transactions with the same nonce it will take just one (filtred in HashMap) fixed by adding a new list for the result
also fixed opening transaction drawer from transaction notification