### PR TITLE
Task-55352: Visual info about Metamask account

### DIFF
--- a/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
@@ -13,6 +13,7 @@ exoplatform.wallet.label.ethereumAddress=Wallet address
 exoplatform.wallet.label.walletPrivateKeyPlaceholder=Enter your digital wallet key
 exoplatform.wallet.label.walletPasswordPlaceholder=Enter wallet password
 exoplatform.wallet.label.walletPassword=Wallet password
+exoplatform.wallet.label.metamask=Metamask :
 exoplatform.wallet.label.newWalletPasswordConfirm=New password confirmation
 exoplatform.wallet.label.walletPasswordPlaceholderConfirm=confirm new password
 exoplatform.wallet.label.copyAddress=Copy Address
@@ -71,6 +72,5 @@ exoplatform.wallet.error.wrongPrivateKey=Private key doesn't match address {0}
 exoplatform.wallet.error.errorImportingPrivateKey=Error importing private key
 exoplatform.wallet.error.errorProcessingNewKeys=Error processing new keys
 exoplatform.wallet.error.walletNotFound=Can't find your wallet
-
 exoplatform.wallet.metamask.welcomeMessage=Welcome to digital workplace \n\nClick to SignIn and accept digital workplace terms. This actions will not trigger a blockchain transaction and or any Gas fees. \n\nWallet address: \n{0} \n\nNonce: \n{1}
 exoplatform.wallet.metamask.message.connectedSuccess=Wallet connected to Metamask successfully !

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -65,7 +65,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               validate-on-blur
               class="mt-n4"
               @input="$emit('amount-selected', amount)" />
-            <p v-if="!storedPassword" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.walletPassword') }}</p>
+            <p v-if="!storedPassword && isInternalWallet" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.walletPassword') }}</p>
+            <p v-else-if="!isInternalWallet" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.settings.internal') }}</p>
             <v-row class="pl-5" v-if="!isInternalWallet">
               <v-col
                 cols="12"
@@ -263,7 +264,7 @@ export default {
       return this.contractDetails && (this.contractDetails.isOwner || !this.transactionFeeInWei || !this.sellPriceInWei ? 0 : toFixed(this.transactionFeeInWei / this.sellPriceInWei));
     },
     isInternalWallet() {
-      return window.walletSettings.wallet.provider === 'INTERNAL_WALLET';
+      return window.walletSettings.wallet?.provider === 'INTERNAL_WALLET';
     },
   },
   watch: {

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -65,7 +65,30 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               validate-on-blur
               class="mt-n4"
               @input="$emit('amount-selected', amount)" />
-
+            <p v-if="!storedPassword" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.walletPassword') }}</p>
+            <v-row class="pl-5" v-if="!isInternalWallet">
+              <v-col
+                cols="12"
+                sm="6" 
+                class="d-flex align-center ml-n5">
+                <img
+                  class="mt-n1"
+                  :src="`/perk-store/images/metamask.svg`"
+                  alt="Metamask"
+                  width="18">
+                <span class="pl-2 amountLabel">{{ $t('exoplatform.wallet.label.metamask') }}</span>
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+                align="right">
+                <v-chip class="grey-background">  
+                  <span class="mr-3 dark-grey-color walletTitle">
+                    {{ metamaskAddressPreview }}
+                  </span>
+                </v-chip>
+              </v-col>
+            </v-row>
             <v-text-field
               v-if="!storedPassword && isInternalWallet"
               ref="walletPassword"
@@ -74,14 +97,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               :type="walletPasswordShow ? 'text' : 'password'"
               :disabled="loading"
               :rules="mandatoryRule"
-              :label="$t('exoplatform.wallet.label.walletPassword')"
               :placeholder="$t('exoplatform.wallet.label.walletPasswordPlaceholder')"
               name="walletPassword"
               required
               validate-on-blur
+              class="mt-n4"
               autocomplete="current-password"
               @click:append="walletPasswordShow = !walletPasswordShow" />
-
             <v-text-field
               v-model="transactionLabel"
               :disabled="loading || transaction"
@@ -207,11 +229,8 @@ export default {
     walletAddress() {
       return this.wallet && this.wallet.address;
     },
-    provider() {
-      return window.walletSettings.wallet?.provider;
-    },
-    isInternalWallet() {
-      return this.provider === 'INTERNAL_WALLET' ;
+    metamaskAddressPreview() {
+      return this.walletAddress && `${this.walletAddress.substring(0,5)}...${this.walletAddress.substring(this.walletAddress.length-4,this.walletAddress.length)}`;
     },
     disabled() {
       return (!this.isSameAddress || !this.isSameNetworkVersion) || (!this.walletAddress || this.loading || !this.gasPrice || !this.recipient || !this.amount || !this.canSendToken || (this.isInternalWallet && (!this.storedPassword && (!this.walletPassword || !this.walletPassword.trim().length))));
@@ -242,6 +261,9 @@ export default {
     },
     transactionFeeToken() {
       return this.contractDetails && (this.contractDetails.isOwner || !this.transactionFeeInWei || !this.sellPriceInWei ? 0 : toFixed(this.transactionFeeInWei / this.sellPriceInWei));
+    },
+    isInternalWallet() {
+      return window.walletSettings.wallet.provider === 'INTERNAL_WALLET';
     },
   },
   watch: {

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -74,7 +74,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 class="d-flex align-center ml-n5">
                 <img
                   class="mt-n1"
-                  :src="`/perk-store/images/metamask.svg`"
+                  :src="`/wallet-common/images/metamask.svg`"
                   alt="Metamask"
                   width="18">
                 <span class="pl-2 amountLabel">{{ $t('exoplatform.wallet.label.metamask') }}</span>


### PR DESCRIPTION
When a user access the wallet to send funds, a visual info about the selected account in Metamask in the "Send funds" drawer is displayed. 