### PR TITLE
TASK-7289: reducing PendingTransactionVerifierJob's schedueled time

### DIFF
--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/blockchain-configuration.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/blockchain-configuration.xml
@@ -149,7 +149,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <property name="jobName" value="PendingTransactionVerifierJob"/>
           <property name="groupName" value="Wallet"/>
           <property name="job" value="org.exoplatform.wallet.job.PendingTransactionVerifierJob"/>
-          <property name="expression" value="${exo.wallet.PendingTransactionVerifierJob.expression:0 15 7 * * ?}"/>
+          <property name="expression" value="${exo.wallet.PendingTransactionVerifierJob.expression:0 0/1 * * * ?}"/>
         </properties-param>
       </init-params>
     </component-plugin>

--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/blockchain-configuration.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/blockchain-configuration.xml
@@ -149,7 +149,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <property name="jobName" value="PendingTransactionVerifierJob"/>
           <property name="groupName" value="Wallet"/>
           <property name="job" value="org.exoplatform.wallet.job.PendingTransactionVerifierJob"/>
-          <property name="expression" value="${exo.wallet.PendingTransactionVerifierJob.expression:0 0/1 * * * ?}"/>
+          <property name="expression" value="${exo.wallet.PendingTransactionVerifierJob.expression:0 0/2 * * * ?}"/>
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
when `sending/receiving` funds, a `pending` transaction that takes too much time to be marked not pending, has been endorsed, although the transaction has been achieved successfully .
In order to `optimize` this delay, the job's `scheduled` expression has been changed into `0 0/2 * * * ?` to make it executable every two minutes .