### PR TITLE
MEED-180: Add a toast success/failure with transaction explorer link notif when sending tokens from wallet .

### DIFF
--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -398,6 +398,7 @@ exoplatform.wallet.message.loadingRecentTransactions=Loading recent transactions
 exoplatform.wallet.message.loadingRecentRewards=Loading recent rewards...
 exoplatform.wallet.message.enterPrivateKeyMessage=Please enter the private key for the following wallet (Find your private key in Backup section)
 exoplatform.wallet.message.importNewPrivateKeyMessage=This is the private key to import a new wallet address
+exoplatform.wallet.message.transactionExplorerLink= Transaction explorer link
 exoplatform.wallet.button.boost=Speedup transaction
 exoplatform.wallet.button.requestAuthorization=Request authorization
 exoplatform.wallet.button.manageKeys=Manage Keys

--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -398,7 +398,7 @@ exoplatform.wallet.message.loadingRecentTransactions=Loading recent transactions
 exoplatform.wallet.message.loadingRecentRewards=Loading recent rewards...
 exoplatform.wallet.message.enterPrivateKeyMessage=Please enter the private key for the following wallet (Find your private key in Backup section)
 exoplatform.wallet.message.importNewPrivateKeyMessage=This is the private key to import a new wallet address
-exoplatform.wallet.message.transactionExplorerLink= Transaction explorer link
+exoplatform.wallet.message.transactionExplorerLink=Transaction explorer link
 exoplatform.wallet.button.boost=Speedup transaction
 exoplatform.wallet.button.requestAuthorization=Request authorization
 exoplatform.wallet.button.manageKeys=Manage Keys
@@ -470,4 +470,4 @@ exoplatform.wallet.label.metamask.welcomeMessage=Welcome to digital workplace \n
 exoplatform.wallet.label.metamask.disabledButton=Metamask is not installed
 exoplatform.wallet.label.metamask.buttonTitle=Connect with metamask Wallet
 
-exoplatform.wallet.metamask.error.transactionFailed= Transaction failed
+exoplatform.wallet.metamask.error.transactionFailed=Transaction failed

--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -468,3 +468,5 @@ exoplatform.wallet.label.createMetamaskWalletLearnMore=Learn more:
 exoplatform.wallet.label.metamask.welcomeMessage=Welcome to digital workplace \n\nClick to SignIn and accept digital workplace terms. This actions will not trigger a blockchain transaction and or any Gas fees. \n\nWallet address: \n{0} \n\nNonce: \n{1}
 exoplatform.wallet.label.metamask.disabledButton=Metamask is not installed
 exoplatform.wallet.label.metamask.buttonTitle=Connect with metamask Wallet
+
+exoplatform.wallet.metamask.error.transactionFailed= Transaction failed

--- a/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
@@ -76,4 +76,4 @@ exoplatform.wallet.error.walletNotFound=Can't find your wallet
 
 exoplatform.wallet.metamask.welcomeMessage=Welcome to digital workplace \n\nClick to SignIn and accept digital workplace terms. This actions will not trigger a blockchain transaction and or any Gas fees. \n\nWallet address: \n{0} \n\nNonce: \n{1}
 exoplatform.wallet.metamask.message.connectedSuccess=Wallet connected to Metamask successfully !
-exoplatform.wallet.metamask.message.transactionSent= Tranasction sent 
+exoplatform.wallet.metamask.message.transactionSent=Tranasction sent 

--- a/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
@@ -23,7 +23,7 @@ exoplatform.wallet.settings.meedsWallet=Meeds Wallet
 exoplatform.wallet.settings.useMetamask=Use Metamask
 exoplatform.wallet.settings.metamaskInstallation=Add Metamask add-on to your browser through this link
 
-exoplatform.wallet.message.followTransaction={0} Link to follow your transaction
+exoplatform.wallet.message.followTransaction={0} link to follow your transaction
 exoplatform.wallet.message.settingsDescription.internal=Your Meeds are as safe as wallet password. Choose it carefully, and never disclose it to anyone.
 exoplatform.wallet.message.settingsDescription.metamask=Your wallet is using a Metamask account.
 exoplatform.wallet.message.deleteWalletConfirmationModal=Do you really want to delete your wallet? This action is irreversible.

--- a/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/wallet-services/src/main/resources/locale/portlet/Portlets_en.properties
@@ -23,6 +23,7 @@ exoplatform.wallet.settings.meedsWallet=Meeds Wallet
 exoplatform.wallet.settings.useMetamask=Use Metamask
 exoplatform.wallet.settings.metamaskInstallation=Add Metamask add-on to your browser through this link
 
+exoplatform.wallet.message.followTransaction={0} Link to follow your transaction
 exoplatform.wallet.message.settingsDescription.internal=Your Meeds are as safe as wallet password. Choose it carefully, and never disclose it to anyone.
 exoplatform.wallet.message.settingsDescription.metamask=Your wallet is using a Metamask account.
 exoplatform.wallet.message.deleteWalletConfirmationModal=Do you really want to delete your wallet? This action is irreversible.
@@ -72,5 +73,7 @@ exoplatform.wallet.error.wrongPrivateKey=Private key doesn't match address {0}
 exoplatform.wallet.error.errorImportingPrivateKey=Error importing private key
 exoplatform.wallet.error.errorProcessingNewKeys=Error processing new keys
 exoplatform.wallet.error.walletNotFound=Can't find your wallet
+
 exoplatform.wallet.metamask.welcomeMessage=Welcome to digital workplace \n\nClick to SignIn and accept digital workplace terms. This actions will not trigger a blockchain transaction and or any Gas fees. \n\nWallet address: \n{0} \n\nNonce: \n{1}
 exoplatform.wallet.metamask.message.connectedSuccess=Wallet connected to Metamask successfully !
+exoplatform.wallet.metamask.message.transactionSent= Tranasction sent 

--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -1097,8 +1097,3 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   }
 }
 
-#WalletNotificationAlert {
-  .v-icon {
-    align-self: center !important;
-  }
-}

--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -1096,3 +1096,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
   }
 }
+
+#WalletNotificationAlert {
+  .v-icon {
+    align-self: center !important;
+  }
+}

--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -1096,4 +1096,3 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
   }
 }
-

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -443,6 +443,7 @@ export default {
       );
       this.$emit('close');
       this.showAlert('success',this.$t('exoplatform.wallet.metamask.message.transactionSent'),savedTransaction.hash);
+      this.close();
       if (notificationId) {
         // Asynchronously mark notification as sent
         markFundRequestAsSent(notificationId);
@@ -627,10 +628,10 @@ export default {
       this.$refs.sendTokensForm.close();
     },
     showAlert(alertType,alertMessage,alertTransactionHash){
-      this.$root.$emit('show-alert', {
+      this.$root.$emit('wallet-notification-alert', {
         type: alertType,
         message: alertMessage,
-        transactionHash: alertTransactionHash
+        transactionHash: alertTransactionHash,
       });
     }
   },

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -550,6 +550,7 @@ export default {
             }
             if (savedTransaction) {
               this.finalizeSendTransaction(savedTransaction, this.contractDetails, this.notificationId);
+              this.close();
             }
           })
           .catch((e) => {
@@ -560,7 +561,6 @@ export default {
           .finally(() => {
             this.loading = false;
             lockBrowserWallet();
-            this.close();
           });
       } else if (this.isMetamaskWallet) {
         if (window.ethereum?.isMetaMask) {
@@ -586,6 +586,7 @@ export default {
               }
               if (savedTransaction) {
                 this.finalizeSendTransaction(savedTransaction, this.contractDetails, this.notificationId);
+                this.close();
               }
             })
             .catch((e) => {
@@ -595,7 +596,6 @@ export default {
             .finally(() => {
               this.loading = false;
               lockBrowserWallet();
-              this.close();
             });}
       } else {
         console.error('Error getting provider');

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -550,7 +550,6 @@ export default {
             }
             if (savedTransaction) {
               this.finalizeSendTransaction(savedTransaction, this.contractDetails, this.notificationId);
-              this.close();
             }
           })
           .catch((e) => {
@@ -586,7 +585,6 @@ export default {
               }
               if (savedTransaction) {
                 this.finalizeSendTransaction(savedTransaction, this.contractDetails, this.notificationId);
-                this.close();
               }
             })
             .catch((e) => {

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -442,7 +442,8 @@ export default {
         contractDetails
       );
       this.$emit('close');
-      this.showAlert('success',this.$t('exoplatform.wallet.metamask.message.transactionSent'),savedTransaction.hash);
+      this.showAlert('success', this.$t('exoplatform.wallet.metamask.message.transactionSent'), 
+        savedTransaction.hash);
       this.close();
       if (notificationId) {
         // Asynchronously mark notification as sent
@@ -556,7 +557,8 @@ export default {
           .catch((e) => {
             console.error('Web3 contract.transfer method - error', e);
             this.error = `${this.$t('exoplatform.wallet.error.emptySendingTransaction')}: ${truncateError(e)}`;
-            this.showAlert('error',this.$t('exoplatform.wallet.metamask.error.transactionFailed',this.savedTransaction.hash));
+            this.showAlert('error', this.$t('exoplatform.wallet.metamask.error.transactionFailed', 
+              this.savedTransaction.hash));
           })
           .finally(() => {
             this.loading = false;
@@ -627,7 +629,7 @@ export default {
     close(){
       this.$refs.sendTokensForm.close();
     },
-    showAlert(alertType,alertMessage,alertTransactionHash){
+    showAlert(alertType, alertMessage, alertTransactionHash){
       this.$root.$emit('wallet-notification-alert', {
         type: alertType,
         message: alertMessage,

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/SendTokensForm.vue
@@ -24,7 +24,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <span> {{ $t('exoplatform.wallet.button.sendfunds') }} </span>
       </div>
     </template>
-    
     <template slot="content">
       <v-card
         id="sendTokenForm"
@@ -401,7 +400,6 @@ export default {
           this.gasPrice = window.walletSettings.network.normalGasPrice;
         }
       }
-
       this.fiatSymbol = window.walletSettings.fiatSymbol;
       this.storedPassword = window.walletSettings.storedPassword && window.walletSettings.browserWalletExists;
       this.$nextTick(() => {
@@ -443,9 +441,8 @@ export default {
         savedTransaction,
         contractDetails
       );
-
       this.$emit('close');
-
+      this.showAlert('success',this.$t('exoplatform.wallet.metamask.message.transactionSent'),savedTransaction.hash);
       if (notificationId) {
         // Asynchronously mark notification as sent
         markFundRequestAsSent(notificationId);
@@ -472,7 +469,6 @@ export default {
         this.error = this.$t('exoplatform.wallet.warning.invalidAmount');
         return;
       }
-
       if (this.isInternalWallet) {
         if (!this.storedPassword && (!this.walletPassword || !this.walletPassword.length)) {
           this.error = this.$t('exoplatform.wallet.warning.requiredPassword');
@@ -514,7 +510,6 @@ export default {
       };
         
       if (this.isInternalWallet) {
-
         Object.assign(transactionDetail, { 
           gas: window.walletSettings.network.gasLimit,
           gasPrice: this.gasPrice,
@@ -522,7 +517,6 @@ export default {
           feeFiat: this.transactionFeeFiat,
           tokenFee: this.transactionFeeToken,
         });
-
         if (this.transaction) {
           Object.assign(transactionDetail, {
             nonce: this.transaction.nonce,
@@ -533,7 +527,6 @@ export default {
             boost: true,
           });
         }
-      
         return transfer(transactionDetail.to, convertTokenAmountToSend(transactionDetail.contractAmount, this.contractDetails.decimals).toString())
           .estimateGas({
             from: transactionDetail.from,
@@ -562,6 +555,7 @@ export default {
           .catch((e) => {
             console.error('Web3 contract.transfer method - error', e);
             this.error = `${this.$t('exoplatform.wallet.error.emptySendingTransaction')}: ${truncateError(e)}`;
+            this.showAlert('error',this.$t('exoplatform.wallet.metamask.error.transactionFailed',this.savedTransaction.hash));
           })
           .finally(() => {
             this.loading = false;
@@ -569,7 +563,6 @@ export default {
             this.close();
           });
       } else if (this.isMetamaskWallet) {
-        
         if (window.ethereum?.isMetaMask) {
           const transactionParameters = {
             to: this.contractDetails.address.toLowerCase(),
@@ -607,21 +600,17 @@ export default {
       } else {
         console.error('Error getting provider');
       }
-      
     },
     checkErrors() {
       this.error = null;
-
       if (!this.contractDetails) {
         return;
       }
-
       if (this.recipient === this.walletAddress && this.contractDetails.contractType > 0) {
         this.error = `You can't send '${this.contractDetails.name}' to yourself`;
         this.canSendToken = false;
         return;
       }
-
       if (this.amount && (isNaN(parseFloat(this.amount)) || !isFinite(this.amount) || this.amount <= 0)) {
         this.error = 'Invalid amount';
         return;
@@ -635,11 +624,17 @@ export default {
         this.updateSelectedMetamaskInformation();
       }
       this.$refs.sendTokensForm.open();
-
     },
     close(){
       this.$refs.sendTokensForm.close();
     },
+    showAlert(alertType,alertMessage,alertTransactionHash){
+      this.$root.$emit('show-alert', {
+        type: alertType,
+        message: alertMessage,
+        transactionHash: alertTransactionHash
+      });
+    }
   },
 };
 </script>

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -14,8 +14,9 @@
           :href="transactionHashLink"
           :title="$t('exoplatform.wallet.message.transactionExplorerLink')"
           rel="external nofollow noreferrer noopener"
+          class="d-block"
           target="_blank">
-          <br>{{ transactionLinkLabel }}
+          {{ transactionLinkLabel }}
         </a>
       </template>
     </exo-notification-alert>
@@ -29,7 +30,7 @@ export default {
   }),
   computed: {
     transactionLinkLabel() {
-      return this.$t('exoplatform.wallet.message.followTransaction', {0: this.walletUtils.getTransactionEtherscanlink()});
+      return this.$t('exoplatform.wallet.message.followTransaction', {0: this.walletUtils.getTransactionExplorerName()});
     },
     transactionHashLink(){
       return this.walletUtils.getTransactionEtherscanlink().concat(this.alert.transactionHash);

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -14,7 +14,7 @@
           :href="transactionHashLink"
           :title="$t('exoplatform.wallet.message.transactionExplorerLink')"
           target="_blank">
-          {{ transactionLinkLabel }}
+          <br>{{ transactionLinkLabel }}
         </a>
       </template>
     </exo-notification-alert>
@@ -31,7 +31,7 @@ export default {
       return this.$t('exoplatform.wallet.message.followTransaction',{0: this.walletUtils.getUrlHostName(this.walletUtils.getTransactionEtherscanlink())});
     },
     transactionHashLink(){
-      return this.alert.transactionHash;
+      return this.walletUtils.getTransactionEtherscanlink().concat(this.alert.transactionHash);
     }
   },
   watch: {

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -8,7 +8,16 @@
     app>
     <exo-notification-alert
       :alert="alert"
-      @dismissed="clear" />
+      @dismissed="clear">
+      <template #actions>
+        <a
+          :href="transactionHashLink"
+          :title="$t('exoplatform.wallet.message.transactionExplorerLink')"
+          target="_blank">
+          {{ transactionLinkLabel }}
+        </a>
+      </template>
+    </exo-notification-alert>
   </v-snackbar>
 </template>
 <script>
@@ -17,15 +26,18 @@ export default {
     snackbar: false,
     alert: null,
   }),
-  watch: {
-    alert() {
-      this.snackbar = !!this.alert;
-    }
-  },
   computed: {
     transactionLinkLabel() {
       return this.$t('exoplatform.wallet.message.followTransaction',{0: this.walletUtils.getUrlHostName(this.walletUtils.getTransactionEtherscanlink())});
     },
+    transactionHashLink(){
+      return this.alert.transactionHash;
+    }
+  },
+  watch: {
+    alert() {
+      this.snackbar = !!this.alert;
+    }
   },
   created() {
     this.$root.$on('wallet-notification-alert', alert => this.alert = alert);

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -13,6 +13,7 @@
         <a
           :href="transactionHashLink"
           :title="$t('exoplatform.wallet.message.transactionExplorerLink')"
+          rel="external nofollow noreferrer noopener"
           target="_blank">
           <br>{{ transactionLinkLabel }}
         </a>

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -20,6 +20,11 @@ export default {
   watch: {
     alert() {
       this.snackbar = !!this.alert;
+    }
+  },
+  computed: {
+    transactionLinkLabel() {
+      return this.$t('exoplatform.wallet.message.followTransaction',{0: this.walletUtils.getUrlHostName(this.walletUtils.getTransactionEtherscanlink())});
     },
   },
   created() {

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletNotificationAlert.vue
@@ -29,7 +29,7 @@ export default {
   }),
   computed: {
     transactionLinkLabel() {
-      return this.$t('exoplatform.wallet.message.followTransaction',{0: this.walletUtils.getUrlHostName(this.walletUtils.getTransactionEtherscanlink())});
+      return this.$t('exoplatform.wallet.message.followTransaction', {0: this.walletUtils.getTransactionEtherscanlink()});
     },
     transactionHashLink(){
       return this.walletUtils.getTransactionEtherscanlink().concat(this.alert.transactionHash);

--- a/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
+++ b/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
@@ -440,6 +440,10 @@ export function getNetworkLink() {
   }
 }
 
+export function getUrlHostName(url){
+  return new URL(url).hostname;
+}
+
 export function getCurrentBrowserWallet() {
   return window && window.localWeb3 && window.localWeb3.eth.accounts.wallet && window.walletSettings.wallet.address && window.localWeb3.eth.accounts.wallet[window.walletSettings.wallet.address];
 }

--- a/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
+++ b/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
@@ -440,10 +440,6 @@ export function getNetworkLink() {
   }
 }
 
-export function getUrlHostName(url){
-  return new URL(url).hostname;
-}
-
 export function getCurrentBrowserWallet() {
   return window && window.localWeb3 && window.localWeb3.eth.accounts.wallet && window.walletSettings.wallet.address && window.localWeb3.eth.accounts.wallet[window.walletSettings.wallet.address];
 }

--- a/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
+++ b/wallet-webapps-common/src/main/webapp/vue-app/js/WalletUtils.js
@@ -372,6 +372,23 @@ export function rememberPassword(remember, password, address) {
   }
 }
 
+export function getTransactionExplorerName() {
+  switch (window.walletSettings.network.id) {
+  case 1:
+    return 'Etherscan';
+  case 3:
+    return 'Ropsten Etherscan';
+  case 5:
+    return 'Goerli Etherscan';
+  case 137:
+    return 'Polygonscan';
+  case 80001:
+    return 'Mumbai Polygonscan';
+  default:
+    return '#';
+  }
+}
+
 export function getAddressEtherscanlink() {
   switch (window.walletSettings.network.id) {
   case 1:


### PR DESCRIPTION
when sending funds, a `ExoNotificationAlert` was needed to describe the `transaction status` before the closing of the `drawer`, whether it's a `success` or a `failure` while precising the the transaction explorer link . 