### PR TITLE
TASK-54927 improve displayed actions menu in wallet administration

### DIFF
--- a/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/wallets/WalletAdminWalletsTab.vue
+++ b/wallet-webapps-admin/src/main/webapp/vue-app/components/admin/wallets/WalletAdminWalletsTab.vue
@@ -147,7 +147,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 size="20" />
               <template v-else>
                 {{ walletUtils.toFixed(props.item.tokenBalance) || 0 }} {{ contractDetails && contractDetails.symbol ? contractDetails.symbol : '' }}
-              </template>
+              </template> 
             </td>
             <td class="clickable text-center" @click="openAccountDetail(props.item)">
               <v-progress-circular
@@ -170,9 +170,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 size="20" />
               <v-menu
                 v-else
-                offset-y
+                attach
+                bottom
+                :left="rtlDisplay"
                 :value="actionSelectedWallet === props.item"
-                attach>
+              >
                 <template
                   #activator="{ on }">
                   <v-btn
@@ -405,6 +407,9 @@ export default {
     displayedWallets() {
       return this.wallets.filter(this.isDisplayWallet);
     },
+    rtlDisplay() {
+      return !this.$vuetify.rtl; 
+    }
   },
   watch: {
     seeAccountDetails() {

--- a/wallet-webapps-common/src/main/webapp/css/main.less
+++ b/wallet-webapps-common/src/main/webapp/css/main.less
@@ -885,15 +885,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
   }
 }
-#WalletAdminApp{
+.options {
+  cursor: pointer;
+}
  .actionsButton{
     color: rgba(0, 0, 0, 0.25) !important;
  }
-  .options {
-    cursor: pointer;
-  }
-}
-
 .walletBackup{
   .copyToClipboardInput{
     position: absolute;


### PR DESCRIPTION
Problem: before this fix,a part of actions menu was hidden out of screen.
fix: change the display position of these actions by adding these options at the `bottom left` inside vuetify component `v-menu`.also, add new computed property `rtlDisplay` that check `rtl` value inside `vuetify` object and this last will enable and disable `left` option  To be better in the design and more readable for all supported languages when activating this menu. also, remove id Selector `#WalletAdminApp` to be these classes (actionsButton, options) accessible for component  `WalletAdminWalletsTab.vue`