### PR TITLE
MEED-313 Make Metamask switch feature available by default in the product

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/settings/UserSettings.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/settings/UserSettings.java
@@ -38,9 +38,6 @@ public class UserSettings extends GlobalSettings {
   private boolean           walletEnabled        = true;
 
   @Exclude
-  private boolean           metamaskEnabled      = false;
-
-  @Exclude
   private boolean           isUseDynamicGasPrice = true;
 
   @Exclude

--- a/wallet-reward-services/src/test/resources/conf/portal/configuration.xml
+++ b/wallet-reward-services/src/test/resources/conf/portal/configuration.xml
@@ -53,11 +53,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-params>
   </component>
 
-  <component>
-      <key>org.exoplatform.commons.api.settings.ExoFeatureService</key>
-      <type>org.exoplatform.settings.impl.ExoFeatureServiceImpl</type>
-  </component>
-
   <import>jar:/conf/portal/wallet-configuration.xml</import>
   <import>jar:/conf/portal/test-wallet-reward-configuration.xml</import>
   <import>jar:/conf/portal/test-organization-configuration.xml</import>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
@@ -28,7 +28,8 @@ import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage;
-import org.exoplatform.commons.api.settings.*;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -46,8 +47,6 @@ import org.exoplatform.wallet.model.transaction.FundsRequest;
  */
 public class WalletServiceImpl implements WalletService, Startable {
 
-  private static final String          METAMASK_FEATURE_NAME    = "walletMetamask";
-
   private static final Log             LOG                      = ExoLogger.getLogger(WalletServiceImpl.class);
 
   private ExoContainer                 container;
@@ -64,8 +63,6 @@ public class WalletServiceImpl implements WalletService, Startable {
 
   private WalletWebSocketService       webSocketService;
 
-  private ExoFeatureService            featureService;
-
   private GlobalSettings               configuredGlobalSettings = new GlobalSettings();
 
   private boolean                      useDynamicGasPrice;
@@ -78,7 +75,6 @@ public class WalletServiceImpl implements WalletService, Startable {
                            WalletAccountService accountService,
                            WalletWebSocketService webSocketService,
                            WebNotificationStorage webNotificationStorage,
-                           ExoFeatureService featureService,
                            PortalContainer container,
                            InitParams params) {
     this.container = container;
@@ -86,7 +82,6 @@ public class WalletServiceImpl implements WalletService, Startable {
     this.contractService = contractService;
     this.webSocketService = webSocketService;
     this.webNotificationStorage = webNotificationStorage;
-    this.featureService = featureService;
 
     NetworkSettings network = this.configuredGlobalSettings.getNetwork();
     if (params.containsKey(NETWORK_ID)) {
@@ -279,7 +274,6 @@ public class WalletServiceImpl implements WalletService, Startable {
       if (isAdministration && isUserMemberOfGroupOrUser(currentUser, REWARDINGS_GROUP)) {
         userSettings.setInitialFunds(getInitialFundsSettings());
       }
-      userSettings.setMetamaskEnabled(featureService.isFeatureActiveForUser(METAMASK_FEATURE_NAME, currentUser));
     }
     if (this.isUseDynamicGasPrice()) {
       userSettings.setUseDynamicGasPrice(true);

--- a/wallet-services/src/main/resources/conf/portal/wallet-configuration.xml
+++ b/wallet-services/src/main/resources/conf/portal/wallet-configuration.xml
@@ -19,18 +19,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
   <component>
-    <key>WalletMetamaskFeatureProperties</key>
-    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
-    <init-params>
-       <properties-param>
-          <name>WalletMetamaskFeatureProperties</name>
-          <description>New Wallet Metamask Feature enablement flag</description>
-          <property name="exo.feature.walletMetamask.enabled" value="${exo.feature.walletMetamask.enabled:false}"/>
-       </properties-param>
-    </init-params>
-  </component>
-
-  <component>
     <type>org.exoplatform.wallet.dao.AddressLabelDAO</type>
   </component>
 

--- a/wallet-services/src/test/resources/conf/portal/configuration.xml
+++ b/wallet-services/src/test/resources/conf/portal/configuration.xml
@@ -75,12 +75,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </value-param>
     </init-params>
   </component>
-
-  <component>
-      <key>org.exoplatform.commons.api.settings.ExoFeatureService</key>
-      <type>org.exoplatform.settings.impl.ExoFeatureServiceImpl</type>
-  </component>
-
   <import>jar:/conf/portal/wallet-configuration.xml</import>
 
   <remove-configuration>org.exoplatform.commons.search.index.IndexingOperationProcessor</remove-configuration>

--- a/wallet-webapps-common/src/main/webapp/vue-app/components/WalletSetup.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/WalletSetup.vue
@@ -51,11 +51,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <i class="uiIconInfo"></i> {{ $t('exoplatform.wallet.info.spaceWalletNotCreatedYet') }}
     </div>
     <wallet-welcome-screen
-      v-if="displayWelcomeScreen && !displayWalletBrowserSetup && !isSpace && metamaskFeatureEnabled"
+      v-if="displayWelcomeScreen && !displayWalletBrowserSetup && !isSpace"
       @create-internal-wallet="displayWalletBrowserSetup = true"
       @configured="refresh()" />
     <wallet-reward-browser-setup
-      v-if="displayWalletBrowserSetup || isSpace || !metamaskFeatureEnabled"
+      v-if="displayWalletBrowserSetup || isSpace"
       ref="walletBrowserSetup"
       :is-space="isSpace"
       :is-space-administrator="isSpaceAdministrator"
@@ -141,9 +141,6 @@ export default {
     displayWelcomeScreen() {
       return this.displayWalletSetup && (this.wallet && !this.wallet.address ||  this.initializationState === 'DELETED');
     },
-    metamaskFeatureEnabled() {
-      return window.walletSettings && window.walletSettings.metamaskEnabled;
-    }
   },
   watch: {
     refreshIndex() {

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-settings/components/WalletSettings.vue
@@ -26,7 +26,7 @@
           :wallet-settings="walletSettings"
           @open-detail="openDetail" />
         <wallet-settings-metamask
-          v-if="metamaskFeatureEnabled && !isSpace"
+          v-if="!isSpace"
           :wallet-settings="walletSettings"
           @open-detail="openDetail" />
       </v-list>
@@ -49,9 +49,6 @@ export default {
     walletSettingsClass() {
       return eXo.env.portal.spaceName ? '': 'ma-4' ;
     },
-    metamaskFeatureEnabled() {
-      return this.walletSettings && this.walletSettings.metamaskEnabled;
-    }
   },
   created() {
     document.addEventListener('hideSettingsApps', (event) => {


### PR DESCRIPTION
Prior to this change, the Metamask switch feature is by default disabled in the product.
this change is going to make it by default available by setting the property exo.feature.walletMetamask.enabled to true