### PR TITLE
MEED-481 fix display status of wallet in administration

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/components/ProfileChip.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/components/ProfileChip.vue
@@ -40,7 +40,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <template v-else-if="disabledInRewardPool">
       {{ displayName }} <span class="red--text">({{ $t('exoplatform.wallet.label.disabledPool') }})</span>
     </template>
-    <template v-else-if="initializationState !== 'INITIALIZED'">
+    <template v-else-if="isNotInitialized">
       {{ displayName }} <span class="orange--text">({{ $t('exoplatform.wallet.label.notInitialized') }})</span>
     </template>
     <template v-else>
@@ -147,6 +147,9 @@ export default {
       }
       return '#';
     },
+    isNotInitialized(){
+      return this.initializationState !== 'INITIALIZED' && this.initializationState !== 'MODIFIED';
+    }
   },
 };
 </script>


### PR DESCRIPTION
prior to this change, when the wallet status is different from "INITIALIZED" its always displayed "(not Initialized)" even if the wallet is modified
after this change when the status is INITIALIZED or MODIFIED no label is displayed