### PR TITLE
feat: Allow to collect blockchain calls through analytics addon - MEED-480

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.exoplatform.social.version>6.4.x-meed-SNAPSHOT</org.exoplatform.social.version>
     <org.exoplatform.wallet.ert-contract.version>1.3.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
     <org.exoplatform.platform-ui.version>6.4.x-meed-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.analytics.version>1.3.x-meed-SNAPSHOT</addon.exo.analytics.version>
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>
@@ -70,6 +71,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.exoplatform.platform-ui</groupId>
         <artifactId>platform-ui</artifactId>
         <version>${org.exoplatform.platform-ui.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.exoplatform.addons.analytics</groupId>
+        <artifactId>analytics-parent</artifactId>
+        <version>${addon.exo.analytics.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -53,6 +53,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.addons.analytics</groupId>
+      <artifactId>analytics-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>jsr250-api</artifactId>
       <scope>provided</scope>
@@ -76,6 +81,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -111,45 +121,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <plugin>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <!-- FIXME: kept until maven-parent-pom:23-M07 is released -->
-      <plugin>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok-maven-plugin</artifactId>
-        <version>1.18.20.0</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>delombok</goal>
-            </goals>
-            <configuration>
-              <addOutputDirectory>false</addOutputDirectory>
-              <sourceDirectory>src/main/java</sourceDirectory>
-            </configuration>
-          </execution>
-          <execution>
-            <id>test-delombok</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>testDelombok</goal>
-            </goals>
-            <configuration>
-              <addOutputDirectory>false</addOutputDirectory>
-              <sourceDirectory>src/test/java</sourceDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- FIXME: kept until maven-parent-pom:23-M07 is released -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-java-compat</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAdminTransactionREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAdminTransactionREST.java
@@ -19,14 +19,11 @@ package org.exoplatform.wallet.rest;
 import static org.exoplatform.wallet.utils.WalletUtils.getCurrentUserId;
 
 import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.*;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
@@ -34,17 +31,20 @@ import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
-import org.exoplatform.wallet.model.settings.InitialFundsSettings;
 import org.exoplatform.wallet.model.transaction.TransactionDetail;
 import org.exoplatform.wallet.service.WalletTokenAdminService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 @Path("/wallet/api/admin/transaction")
 @RolesAllowed("rewarding")
 @Tag(name = "/wallet/api/admin/transaction", description = "Manages admin wallet transactions to send on blockchain")
 public class WalletAdminTransactionREST implements ResourceContainer {
-
-  private static final String     BAD_REQUEST_SENT_TO_SERVER_BY = "Bad request sent to server by '";
 
   private static final Log        LOG                           = ExoLogger.getLogger(WalletAdminTransactionREST.class);
 
@@ -69,7 +69,6 @@ public class WalletAdminTransactionREST implements ResourceContainer {
                                   @Parameter(description = "transaction message to send to receiver with transaction") @FormParam("transactionMessage") String transactionMessage) {
     String currentUserId = getCurrentUserId();
     if (StringUtils.isBlank(receiver)) {
-      LOG.warn(BAD_REQUEST_SENT_TO_SERVER_BY + currentUserId + "' with empty address");
       return Response.status(HTTPStatus.BAD_REQUEST).build();
     }
 
@@ -115,7 +114,6 @@ public class WalletAdminTransactionREST implements ResourceContainer {
                             @Parameter(description = "transaction message to send to receiver with transaction") @FormParam("transactionMessage") String transactionMessage) {
     String currentUserId = getCurrentUserId();
     if (StringUtils.isBlank(receiver)) {
-      LOG.warn(BAD_REQUEST_SENT_TO_SERVER_BY + currentUserId + "' with empty address");
       return Response.status(HTTPStatus.BAD_REQUEST).build();
     }
     if (etherAmount <= 0) {
@@ -155,7 +153,6 @@ public class WalletAdminTransactionREST implements ResourceContainer {
                             @Parameter(description = "value of token to send to receiver") @FormParam("tokenAmount") double tokenAmount) {
     String currentUserId = getCurrentUserId();
     if (StringUtils.isBlank(receiver)) {
-      LOG.warn(BAD_REQUEST_SENT_TO_SERVER_BY + currentUserId + "' with empty address");
       return Response.status(HTTPStatus.BAD_REQUEST).build();
     }
 

--- a/wallet-api/src/main/java/org/exoplatform/wallet/service/WalletTokenAdminService.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/service/WalletTokenAdminService.java
@@ -146,8 +146,6 @@ public interface WalletTokenAdminService {
 
   /**
    * Boosts the transaction issued from Admin wallet by increasing the gas price
-   * @return {@link TransactionDetail} with the new gas price boosted and the hash of the transaction sent in
-   *         blockchain
    */
-  void boostAdminTransactions() throws Exception;
+  void boostAdminTransactions();
 }

--- a/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
@@ -16,7 +16,14 @@
  */
 package org.exoplatform.wallet.statistic;
 
-import static org.exoplatform.wallet.statistic.StatisticUtils.*;
+import static org.exoplatform.wallet.statistic.StatisticUtils.DURATION;
+import static org.exoplatform.wallet.statistic.StatisticUtils.ERROR_MSG;
+import static org.exoplatform.wallet.statistic.StatisticUtils.LOCAL_SERVICE;
+import static org.exoplatform.wallet.statistic.StatisticUtils.OPERATION;
+import static org.exoplatform.wallet.statistic.StatisticUtils.REMOTE_SERVICE;
+import static org.exoplatform.wallet.statistic.StatisticUtils.STATUS;
+import static org.exoplatform.wallet.statistic.StatisticUtils.STATUS_CODE;
+import static org.exoplatform.wallet.statistic.StatisticUtils.addStatisticEntry;
 
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -27,6 +34,9 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -58,6 +68,11 @@ public class ExoWalletStatisticAspect {
     String errorMessage = null;
     long startTime = System.currentTimeMillis();
     Object result = null;
+    ExoContainer currentContainer = ExoContainerContext.getCurrentContainerIfPresent();
+    boolean replaceCurrentContainer = !(currentContainer instanceof PortalContainer);
+    if (replaceCurrentContainer) {
+      ExoContainerContext.setCurrentContainer(PortalContainer.getInstance());
+    }
     try {
       result = point.proceed();
       return result;
@@ -98,6 +113,10 @@ public class ExoWalletStatisticAspect {
         }
       } catch (Throwable e) {
         LOG.warn("Error adding statistic log entry in method '{}' for statistic type '{}'", method.getName(), operation, e);
+      } finally {
+        if (replaceCurrentContainer) {
+          ExoContainerContext.setCurrentContainer(currentContainer);
+        }
       }
     }
   }

--- a/wallet-api/src/main/java/org/exoplatform/wallet/statistic/StatisticUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/statistic/StatisticUtils.java
@@ -16,126 +16,217 @@
  */
 package org.exoplatform.wallet.statistic;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.analytics.model.StatisticData;
+import org.exoplatform.analytics.model.StatisticData.StatisticStatus;
+import org.exoplatform.analytics.utils.AnalyticsUtils;
+import org.exoplatform.commons.api.settings.ExoFeatureService;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.wallet.model.Wallet;
+import org.exoplatform.wallet.utils.WalletUtils;
 
 public class StatisticUtils {
 
-  private static final Log STATISTIC_LOG = ExoLogger.getLogger("WalletStatistics");
+  public static final String         WALLET_ANALYTICS_FEATURE_NAME = "wallet.analytics";
+
+  public static final String         LOCAL_SERVICE                 = "local_service";
+
+  public static final String         REMOTE_SERVICE                = "remote_service";
+
+  public static final String         OPERATION                     = "operation";
+
+  public static final String         STATUS                        = "status";
+
+  public static final String         STATUS_CODE                   = "status_code";
+
+  public static final String         DURATION                      = "duration_ms";
+
+  public static final String         ERROR_MSG                     = "error_msg";
+
+  public static final String         PARAMETERS                    = "parameters";
+
+  protected static Log               log                           = ExoLogger.getLogger("WalletStatistics");
+
+  protected static ExoFeatureService featureService;
 
   private StatisticUtils() {
   }
 
-  public static final String LOCAL_SERVICE  = "local_service";
+  public static void addStatisticEntry(Map<String, Object> parameters) {
+    addStatisticEntry(parameters, StatisticUtils::logStatistics, StatisticUtils::addAnalyticsEntry);
+  }
 
-  public static final String REMOTE_SERVICE = "remote_service";
-
-  public static final String OPERATION      = "operation";
-
-  public static final String STATUS         = "status";
-
-  public static final String STATUS_CODE    = "status_code";
-
-  public static final String DURATION       = "duration_ms";
-
-  public static final String ERROR_MSG      = "error_msg";
-
-  public static final String PARAMETERS     = "parameters";
-
-  public static void addStatisticEntry(Map<String, Object> parameters) { // NOSONAR
+  protected static void addStatisticEntry(Map<String, Object> parameters, // NOSONAR
+                                          Consumer<String> logConsumer,
+                                          Consumer<StatisticData> analyticsConsumer) {
     if (parameters == null || parameters.isEmpty()) {
       throw new IllegalArgumentException("parameters is mandatory");
     }
 
     parameters = new HashMap<>(parameters);
-    StringBuilder logEntry = new StringBuilder();
 
-    if (parameters.containsKey(LOCAL_SERVICE)) {
-      logEntry.append(LOCAL_SERVICE).append("=").append(parameters.get(LOCAL_SERVICE)).append(" ");
-      parameters.remove(LOCAL_SERVICE);
-    } else if (parameters.containsKey(REMOTE_SERVICE)) {
-      logEntry.append(REMOTE_SERVICE).append("=").append(parameters.get(REMOTE_SERVICE)).append(" ");
-      parameters.remove(REMOTE_SERVICE);
-    } else {
-      throw new IllegalStateException("neither 'local_service' nor 'remote_service' exists in parameters");
-    }
+    if (getFeatureService().isActiveFeature(WALLET_ANALYTICS_FEATURE_NAME)) {
+      String subModule = (String) parameters.remove(REMOTE_SERVICE);
+      if (StringUtils.isBlank(subModule)) {
+        subModule = (String) parameters.remove(LOCAL_SERVICE);
+      }
+      String operation = (String) parameters.remove(OPERATION);
+      String status = (String) parameters.remove(STATUS);
+      String statusCode = (String) parameters.remove(STATUS_CODE);
+      String errorMessage = (String) parameters.remove(ERROR_MSG);
+      Long duration = (Long) parameters.remove(DURATION);
 
-    if (parameters.containsKey(OPERATION)) {
-      logEntry.append(OPERATION).append("=").append(parameters.get(OPERATION)).append(" ");
-      parameters.remove(OPERATION);
-    } else {
-      throw new IllegalStateException("'OPERATION' doesn't exists in parameters");
-    }
+      StatisticData statisticData = new StatisticData();
+      statisticData.setModule("wallet");
+      statisticData.setSubModule(subModule);
+      statisticData.setOperation(operation);
+      if (ConversationState.getCurrent() != null) {
+        statisticData.setUserId(WalletUtils.getCurrentUserIdentityId());
+      }
+      if (duration != null && duration > 0) {
+        statisticData.setDuration(duration.longValue());
+      }
+      if (StringUtils.isNotBlank(status)) {
+        statisticData.setStatus(StatisticStatus.valueOf(status.toUpperCase()));
+      }
+      if (StringUtils.isNotBlank(statusCode) && !StringUtils.equals(statusCode, "200")) {
+        statisticData.setErrorCode(Long.parseLong(statusCode));
+      }
+      if (StringUtils.isNotBlank(errorMessage)) {
+        statisticData.setErrorMessage(errorMessage);
+      }
 
-    if (parameters.containsKey(STATUS)) {
-      logEntry.append(STATUS).append("=").append(parameters.get(STATUS)).append(" ");
-      parameters.remove(STATUS);
-    }
+      Iterator<Entry<String, Object>> parametersIterator = parameters.entrySet().iterator();
+      while (parametersIterator.hasNext()) {
+        Map.Entry<String, Object> entry = parametersIterator.next();
+        String key = entry.getKey();
+        Object value = entry.getValue();
+        if (value instanceof Wallet) {
+          parametersIterator.remove();
 
-    if (parameters.containsKey(STATUS_CODE)) {
-      logEntry.append(STATUS_CODE).append("=").append(parameters.get(STATUS_CODE)).append(" ");
-      parameters.remove(STATUS_CODE);
-    }
-
-    if (parameters.containsKey(DURATION)) {
-      logEntry.append(DURATION).append("=").append(parameters.get(DURATION)).append(" ");
-      parameters.remove(DURATION);
-    }
-
-    if (parameters.containsKey(ERROR_MSG)) {
-      logEntry.append(ERROR_MSG).append("=").append(parameters.get(ERROR_MSG)).append(" ");
-      parameters.remove(ERROR_MSG);
-    }
-
-    logEntry.append(PARAMETERS).append("=").append("\"");
-    Set<Entry<String, Object>> parametersEntries = parameters.entrySet();
-    Iterator<Entry<String, Object>> parametersIterator = parametersEntries.iterator();
-    while (parametersIterator.hasNext()) {
-      Map.Entry<String, Object> entry = parametersIterator.next();
-      String key = entry.getKey();
-      Object value = entry.getValue();
-      if (value instanceof String) {
-        logEntry.append(key).append(":").append(value);
-      } else if (value instanceof Wallet) {
-        String prefix = key;
-        if (StringUtils.isBlank(prefix)) {
-          prefix = "";
-        } else {
-          prefix = prefix + "_"; // NOSONAR
+          Wallet wallet = (Wallet) value;
+          String prefix = key.replace("wallet", "").replace("Wallet", "");
+          if (StringUtils.isBlank(prefix)) {
+            statisticData.addParameter(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID, wallet.getTechnicalId());
+            statisticData.addParameter("walletAddress", wallet.getAddress());
+          } else {
+            String entryKey = prefix + StringUtils.capitalize(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID);
+            statisticData.addParameter(entryKey, wallet.getTechnicalId());
+            statisticData.addParameter(prefix + "WalletAddress", wallet.getAddress());
+          }
         }
-        Wallet wallet = (Wallet) value;
-        logEntry.append(prefix)
-                .append("identity_id:")
-                .append(wallet.getTechnicalId())
-                .append(",")
-                .append(prefix)
-                .append("identity_type:")
-                .append(wallet.getType())
-                .append(",")
-                .append(prefix)
-                .append("wallet_address:")
-                .append(wallet.getAddress());
-      } else {
-        logEntry.append(key).append(":").append(value);
       }
-      parametersIterator.remove();
-      if (!parameters.isEmpty()) {
-        logEntry.append(",");
-      }
-    }
-    logEntry.append("\"");
+      parameters.forEach(statisticData::addParameter);
+      analyticsConsumer.accept(statisticData);
+    } else if (log.isDebugEnabled()) {
+      StringBuilder logEntry = new StringBuilder();
 
-    STATISTIC_LOG.debug(logEntry.toString());
+      logEntry.append(PARAMETERS).append("=").append("\"");
+      Set<Entry<String, Object>> parametersEntries = parameters.entrySet();
+      Iterator<Entry<String, Object>> parametersIterator = parametersEntries.iterator();
+      while (parametersIterator.hasNext()) {
+        Map.Entry<String, Object> entry = parametersIterator.next();
+        String key = entry.getKey();
+        Object value = entry.getValue();
+        if (value instanceof String) {
+          logEntry.append(key).append(":").append(value);
+        } else if (value instanceof Wallet) {
+          String prefix = key;
+          if (StringUtils.isBlank(prefix)) {
+            prefix = "";
+          } else {
+            prefix = prefix + "_"; // NOSONAR
+          }
+          Wallet wallet = (Wallet) value;
+          logEntry.append(prefix)
+                  .append("identity_id:")
+                  .append(wallet.getTechnicalId())
+                  .append(",")
+                  .append(prefix)
+                  .append("identity_type:")
+                  .append(wallet.getType())
+                  .append(",")
+                  .append(prefix)
+                  .append("wallet_address:")
+                  .append(wallet.getAddress());
+        } else {
+          logEntry.append(key).append(":").append(value);
+        }
+        if (!parameters.isEmpty()) {
+          logEntry.append(",");
+        }
+      }
+      logEntry.append("\"");
+
+      if (parameters.containsKey(LOCAL_SERVICE)) {
+        logEntry.append(LOCAL_SERVICE).append("=").append(parameters.remove(LOCAL_SERVICE)).append(" ");
+        parameters.remove(LOCAL_SERVICE);
+      } else if (parameters.containsKey(REMOTE_SERVICE)) {
+        logEntry.append(REMOTE_SERVICE).append("=").append(parameters.remove(REMOTE_SERVICE)).append(" ");
+        parameters.remove(REMOTE_SERVICE);
+      } else {
+        throw new IllegalStateException("neither 'local_service' nor 'remote_service' exists in parameters");
+      }
+
+      if (parameters.containsKey(OPERATION)) {
+        logEntry.append(OPERATION).append("=").append(parameters.remove(OPERATION)).append(" ");
+        parameters.remove(OPERATION);
+      } else {
+        throw new IllegalStateException("'OPERATION' doesn't exists in parameters");
+      }
+
+      if (parameters.containsKey(STATUS)) {
+        logEntry.append(STATUS).append("=").append(parameters.remove(STATUS)).append(" ");
+        parameters.remove(STATUS);
+      }
+
+      if (parameters.containsKey(STATUS_CODE)) {
+        logEntry.append(STATUS_CODE).append("=").append(parameters.remove(STATUS_CODE)).append(" ");
+        parameters.remove(STATUS_CODE);
+      }
+
+      if (parameters.containsKey(DURATION)) {
+        logEntry.append(DURATION).append("=").append(parameters.remove(DURATION)).append(" ");
+        parameters.remove(DURATION);
+      }
+
+      if (parameters.containsKey(ERROR_MSG)) {
+        logEntry.append(ERROR_MSG).append("=").append(parameters.remove(ERROR_MSG)).append(" ");
+        parameters.remove(ERROR_MSG);
+      }
+
+      logConsumer.accept(logEntry.toString());
+    }
   }
 
   public static final String transformCapitalWithUnderscore(String string) {
     return string.replaceAll("([A-Z])", "_$1").toLowerCase();
+  }
+
+  protected static ExoFeatureService getFeatureService() {
+    if (featureService == null) {
+      featureService = ExoContainerContext.getService(ExoFeatureService.class);
+    }
+    return featureService;
+  }
+
+  protected static void addAnalyticsEntry(StatisticData statisticData) {
+    AnalyticsUtils.addStatisticData(statisticData);
+  }
+
+  protected static void logStatistics(String string) {
+    log.debug(string);
   }
 
 }

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -289,6 +289,14 @@ public class WalletUtils {
 
   public static final String                          OPERATION_GET_TRANSACTION_COUNT          = "eth_getTransactionCount";
 
+  public static final String                          OPERATION_GET_FILTER_LOGS                = "getFilterLogs";
+
+  public static final String                          OPERATION_NEW_FILTER                     = "eth_newFilter";
+
+  public static final String                          OPERATION_UNINSTALL_FILTER               = "eth_uninstallFilter";
+
+  public static final String                          OPERATION_GET_FILTER_CHANGES             = "eth_getFilterChanges";
+
   public static final String                          OPERATION_GET_GAS_PRICE                  = "eth_getGasPrice";
 
   public static final String                          OPERATION_READ_FROM_TOKEN                = "eth_call";

--- a/wallet-api/src/test/java/org/exoplatform/wallet/statistic/StatisticUtilsTest.java
+++ b/wallet-api/src/test/java/org/exoplatform/wallet/statistic/StatisticUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
+ * Copyright (C) 2022 Meeds Association
  * contact@meeds.io
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/wallet-api/src/test/java/org/exoplatform/wallet/statistic/StatisticUtilsTest.java
+++ b/wallet-api/src/test/java/org/exoplatform/wallet/statistic/StatisticUtilsTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.wallet.statistic;
+
+import static org.exoplatform.wallet.statistic.StatisticUtils.DURATION;
+import static org.exoplatform.wallet.statistic.StatisticUtils.ERROR_MSG;
+import static org.exoplatform.wallet.statistic.StatisticUtils.LOCAL_SERVICE;
+import static org.exoplatform.wallet.statistic.StatisticUtils.OPERATION;
+import static org.exoplatform.wallet.statistic.StatisticUtils.REMOTE_SERVICE;
+import static org.exoplatform.wallet.statistic.StatisticUtils.STATUS;
+import static org.exoplatform.wallet.statistic.StatisticUtils.STATUS_CODE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.analytics.model.StatisticData;
+import org.exoplatform.analytics.model.StatisticData.StatisticStatus;
+import org.exoplatform.analytics.utils.AnalyticsUtils;
+import org.exoplatform.commons.api.settings.ExoFeatureService;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.wallet.model.Wallet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StatisticUtilsTest {
+
+  @Mock
+  ExoFeatureService featureService;
+
+  @Test
+  public void testParameterValidation() {
+    assertThrows(IllegalArgumentException.class, () -> StatisticUtils.addStatisticEntry(null));
+    assertThrows(IllegalArgumentException.class, () -> StatisticUtils.addStatisticEntry(Collections.emptyMap())); // NOSONAR
+  }
+
+  @Test
+  public void testIsAnalyticsFeatureEnabled() {
+    StatisticUtils.featureService = featureService;
+    when(featureService.isActiveFeature(StatisticUtils.WALLET_ANALYTICS_FEATURE_NAME)).thenReturn(true);
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put(REMOTE_SERVICE, "REMOTE_SERVICE");
+    parameters.put(OPERATION, "OPERATION");
+    parameters.put(STATUS, "KO");
+    parameters.put(STATUS_CODE, "500");
+    parameters.put(ERROR_MSG, "ERROR_MSG");
+    parameters.put(DURATION, 1220l);
+
+    Wallet toWallet = addWallet(parameters, "to", 1l, "toWallet");
+    Wallet fromWallet = addWallet(parameters, "fromWallet", 2l, "fromWallet");
+    Wallet byWallet = addWallet(parameters, "byWallet", 1l, "byWallet");
+    Wallet wallet = addWallet(parameters, "wallet", 1l, "wallet");
+
+    AtomicInteger logConsumerInvocationCount = new AtomicInteger();
+    AtomicReference<StatisticData> statisticDataReference = new AtomicReference<>();
+    StatisticUtils.addStatisticEntry(new HashMap<>(parameters),
+                                     logEntry -> logConsumerInvocationCount.incrementAndGet(),
+                                     statisticData -> statisticDataReference.set(statisticData));
+    assertEquals(0, logConsumerInvocationCount.get());
+
+    StatisticData statisticData = statisticDataReference.get();
+    assertNotNull(statisticData);
+    assertEquals("wallet", statisticData.getModule());
+    assertEquals(parameters.get(REMOTE_SERVICE), statisticData.getSubModule());
+    assertEquals(parameters.get(OPERATION), statisticData.getOperation());
+    assertEquals(parameters.get(ERROR_MSG), statisticData.getErrorMessage());
+    assertEquals(Long.parseLong(parameters.get(DURATION).toString()), statisticData.getDuration());
+    assertEquals(StatisticStatus.valueOf(parameters.get(STATUS).toString().toUpperCase()), statisticData.getStatus());
+    assertEquals(Long.parseLong(parameters.get(STATUS_CODE).toString()), statisticData.getErrorCode());
+    assertEquals(0, statisticData.getUserId());
+    assertEquals(String.valueOf(toWallet.getTechnicalId()), statisticData.getParameters().get("toIdentityId"));
+    assertEquals(toWallet.getAddress(), statisticData.getParameters().get("toWalletAddress"));
+    assertEquals(String.valueOf(fromWallet.getTechnicalId()), statisticData.getParameters().get("fromIdentityId"));
+    assertEquals(fromWallet.getAddress(), statisticData.getParameters().get("fromWalletAddress"));
+    assertEquals(String.valueOf(byWallet.getTechnicalId()), statisticData.getParameters().get("byIdentityId"));
+    assertEquals(byWallet.getAddress(), statisticData.getParameters().get("byWalletAddress"));
+    assertEquals(String.valueOf(wallet.getTechnicalId()),
+                 statisticData.getParameters().get(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID));
+    assertEquals(wallet.getAddress(), statisticData.getParameters().get("walletAddress"));
+  }
+
+  @Test
+  public void testIsAnalyticsFeatureDisabled() {
+    StatisticUtils.featureService = featureService;
+    when(featureService.isActiveFeature(StatisticUtils.WALLET_ANALYTICS_FEATURE_NAME)).thenReturn(false);
+    Log logger = mock(Log.class);
+    StatisticUtils.log = logger;
+    when(logger.isDebugEnabled()).thenReturn(true);
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put(LOCAL_SERVICE, "REMOTE_SERVICE");
+    parameters.put(OPERATION, "OPERATION");
+    parameters.put(STATUS, "KO");
+    parameters.put(STATUS_CODE, "500");
+    parameters.put(ERROR_MSG, "ERROR_MSG");
+    parameters.put(DURATION, "1220");
+
+    addWallet(parameters, "to", 1l, "toWallet");
+    addWallet(parameters, "fromWallet", 2l, "fromWallet");
+    addWallet(parameters, "byWallet", 1l, "byWallet");
+    addWallet(parameters, "wallet", 1l, "wallet");
+
+    AtomicInteger logConsumerInvocationCount = new AtomicInteger();
+    AtomicInteger analyticsConsumerInvocationCount = new AtomicInteger();
+    StatisticUtils.addStatisticEntry(new HashMap<>(parameters),
+                                     logEntry -> logConsumerInvocationCount.incrementAndGet(),
+                                     statisticData -> analyticsConsumerInvocationCount.incrementAndGet());
+    assertEquals(1, logConsumerInvocationCount.get());
+    assertEquals(0, analyticsConsumerInvocationCount.get());
+  }
+
+  private Wallet addWallet(Map<String, Object> parameters, String key, long technicalId, String address) {
+    Wallet toWallet = new Wallet();
+    toWallet.setTechnicalId(technicalId);
+    toWallet.setAddress(address);
+    parameters.put(key, toWallet);
+    return toWallet;
+  }
+
+}

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -34,6 +34,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.addons.analytics</groupId>
+      <artifactId>analytics-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wallet-services</artifactId>
       <scope>test</scope>

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardTeamStorage.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardTeamStorage.java
@@ -45,7 +45,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
   @Override
   public List<RewardTeam> getTeams() {
     List<RewardTeamEntity> teamEntities = rewardTeamDAO.findNotDeletedTeams();
-    return teamEntities.stream().map(teamEntity -> toDTO(teamEntity)).collect(Collectors.toList());
+    return teamEntities.stream().map(WalletRewardTeamStorage::toDTO).collect(Collectors.toList());
   }
 
   @Override
@@ -87,7 +87,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
   @Override
   public List<RewardTeam> findTeamsByMemberId(long identityId) {
     List<RewardTeamEntity> entities = rewardTeamDAO.findTeamsByMemberId(identityId);
-    return entities.stream().map(team -> toDTO(team)).collect(Collectors.toList());
+    return entities.stream().map(WalletRewardTeamStorage::toDTO).collect(Collectors.toList());
   }
 
   @Override
@@ -148,7 +148,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
     if (teamEntity.getMembers() != null && !teamEntity.getMembers().isEmpty()) {
       List<RewardTeamMember> list = teamEntity.getMembers()
                                               .stream()
-                                              .map(teamMemberEntity -> getRewardTeamMember(teamMemberEntity))
+                                              .map(WalletRewardTeamStorage::getRewardTeamMember)
                                               .collect(Collectors.toList());
       rewardTeam.setMembers(new ArrayList<>(list));
     }
@@ -185,7 +185,7 @@ public class WalletRewardTeamStorage implements RewardTeamStorage {
       return null;
     }
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    Identity identity = identityManager.getIdentity(String.valueOf(identityId), true);
+    Identity identity = identityManager.getIdentity(String.valueOf(identityId));
     if (identity == null) {
       return null;
     }

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -25,14 +25,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-services</artifactId>
   <name>eXo Add-on:: Wallet - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.61</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.62</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wallet-api</artifactId>
       <scope>provided</scope>
-      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.addons.analytics</groupId>
+      <artifactId>analytics-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.ws</groupId>
@@ -127,13 +131,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.addons.wallet</groupId>
-      <artifactId>wallet-api</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionService.java
@@ -266,7 +266,7 @@ public class EthereumBlockchainTransactionService implements BlockchainTransacti
   public Future startWatchingBlockchain() {
     long lastWatchedBlockNumber = getLastWatchedBlockNumber();
     if (lastWatchedBlockNumber == 0) {
-      lastWatchedBlockNumber = ethereumClientConnector.getLastestBlockNumber();
+      lastWatchedBlockNumber = ethereumClientConnector.getLastestBlockNumber() - 1;
       saveLastWatchedBlockNumber(lastWatchedBlockNumber);
     }
     ethereumClientConnector.setLastWatchedBlockNumber(lastWatchedBlockNumber);

--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
@@ -391,7 +391,7 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
   }
 
   @Override
-  public void boostAdminTransactions() throws Exception {
+  public void boostAdminTransactions() {
     List<TransactionDetail> pendingTransactions =
                                                 getTransactionService().getPendingWalletTransactionsSent(getAdminWalletAddress());
     double gasPrice = walletService.getGasPrice();
@@ -492,7 +492,7 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
     return (BigInteger) executeReadOperation(contractAddress, MeedsToken.FUNC_BALANCEOF, address);
   }
 
-  @ExoWalletStatistic(service = "org/exoplatform/wallet/blockchain", local = false, operation = OPERATION_READ_FROM_TOKEN)
+  @ExoWalletStatistic(service = "blockchain", local = false, operation = OPERATION_READ_FROM_TOKEN)
   public Object executeReadOperation(final String contractAddress,
                                      final String methodName,
                                      final Object... arguments) throws Exception {

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
+ * Copyright (C) 2022 Meeds Association
  * contact@meeds.io
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2009 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.wallet.service;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
+import org.picocontainer.Startable;
+
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.RootContainer;
+
+/**
+ * A container listener that will allow to add wallet analytics page when
+ * feature is enabled
+ */
+public class WalletAnalyticsProfileService implements Startable {
+
+  @Override
+  public void start() {
+    if (StringUtils.equals(PropertyManager.getProperty("exo.feature.wallet.analytics.enabled"), "true")) {
+      RootContainer.addProfiles(Collections.singleton("wallet-analytics"));
+    }
+  }
+
+  @Override
+  public void stop() {
+    // Nothing to stop
+  }
+
+}

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAnalyticsProfileService.java
@@ -1,20 +1,18 @@
 /*
- * Copyright (C) 2009 eXo Platform SAS.
- *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.exoplatform.wallet.service;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
@@ -56,10 +56,12 @@ public class WalletStorage {
     this.privateKeyDAO = privateKeyDAO;
     this.blockchainStateDAO = blockchainStateDAO;
 
-    try {
-      this.codec = codecInitializer.getCodec();
-    } catch (Exception e) {
-      LOG.error("Error initializing codecs", e);
+    if (codecInitializer != null) {
+      try {
+        this.codec = codecInitializer.getCodec();
+      } catch (Exception e) {
+        LOG.error("Error initializing codecs", e);
+      }
     }
   }
 

--- a/wallet-services/src/main/resources/conf/configuration.xml
+++ b/wallet-services/src/main/resources/conf/configuration.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the Meeds project (https://meeds.io/).
+Copyright (C) 2022 Meeds Association
+contact@meeds.io
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <component>
+    <key>WalletAnalyticsProperties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>WalletAnalyticsProperties</name>
+        <description>Wallet Analytics integration feature flag</description>
+        <property name="exo.feature.wallet.analytics.enabled" value="${exo.feature.wallet.analytics.enabled:false}" />
+      </properties-param>
+    </init-params>
+  </component>
+
+  <component>
+    <type>org.exoplatform.wallet.service.WalletAnalyticsProfileService</type>
+  </component>
+
+</configuration>

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAnalyticsProfileServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAnalyticsProfileServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
+ * Copyright (C) 2022 Meeds Association
  * contact@meeds.io
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAnalyticsProfileServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAnalyticsProfileServiceTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.wallet.service;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer;
+
+public class WalletAnalyticsProfileServiceTest {
+
+  @Before
+  public void setup() {
+    PortalContainer.getInstance();
+  }
+
+  @Test
+  public void testWalletAnalyticsDisabledByDefault() {
+    assertFalse(RootContainer.getProfiles().contains("wallet-analytics"));
+  }
+
+}

--- a/wallet-services/src/test/java/org/exoplatform/wallet/test/mock/EthereumWalletTokenAdminServiceMock.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/test/mock/EthereumWalletTokenAdminServiceMock.java
@@ -65,7 +65,7 @@ public class EthereumWalletTokenAdminServiceMock implements WalletTokenAdminServ
   }
 
   @Override
-  public void boostAdminTransactions() throws Exception {
+  public void boostAdminTransactions() {
 
   }
 }

--- a/wallet-webapps-common/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/wallet-webapps-common/src/main/resources/locale/navigation/portal/global_en.properties
@@ -19,3 +19,4 @@ portal.global.wallet.settings=Wallet settings
 wallet.navigation.Reward=Rewards
 wallet.navigation.Kudos=Kudos
 wallet.navigation.Wallet=Wallet
+wallet.navigation.analyticsWallet=Wallet Analytics

--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -25,6 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <import>war:/conf/wallet/bundle-configuration.xml</import>
   <import>war:/conf/wallet/organization-configuration.xml</import>
   <import>war:/conf/wallet/portal-configuration.xml</import>
+  <import profiles="wallet-analytics">war:/conf/wallet/analytics/portal-configuration.xml</import>
   <import>war:/conf/wallet/dynamic-container-configuration.xml</import>
   <import>war:/conf/wallet/application-registry-configuration.xml</import>
   <import>war:/conf/wallet/user-page-configuration.xml</import>

--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal-configuration.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal-configuration.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.portal.config.UserPortalConfigService</target-component>
+    <component-plugin>
+      <name>new.portal.config.user.listener</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <description>This listener creates Wallet Analytics Page</description>
+      <init-params>
+        <value-param>
+          <name>override</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>portal.configuration</name>
+          <description>description</description>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.wallet.analytics.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.wallet.analytics.portalConfig.metadata.importmode:insert}</string>
+            </field>
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>global</string>
+                </value>
+              </collection>
+            </field>
+            <field name="location">
+              <string>war:/conf/wallet/analytics/</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal/global/navigation.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal/global/navigation.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<node-navigation
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+  <priority>3</priority>
+
+  <page-nodes>
+    <node>
+      <name>analytics</name>
+      <label>#{analytics.navigation.Analytics}</label>
+      <visibility>SYSTEM</visibility>
+      <page-reference>portal::global::analytics</page-reference>
+      <node>
+        <name>analyticsWallet</name>
+        <label>#{wallet.navigation.analyticsWallet}</label>
+        <visibility>DISPLAYED</visibility>
+        <page-reference>portal::global::analytics-wallet</page-reference>
+      </node>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal/global/pages.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/analytics/portal/global/pages.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2022 Meeds Association
+  contact@meeds.io
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<page-set
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_objects_1_8 http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
+  xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8">
+
+  <page>
+    <name>analytics-wallet</name>
+    <title>Analytics Wallet</title>
+    <access-permissions>*:/platform/analytics;*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/analytics</edit-permission>
+    <container id="topAnalyticsPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication border-box-sizing">
+      <access-permissions>Everyone</access-permissions>
+      <container id="breadcrumbAnalytics" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+        <access-permissions>Everyone</access-permissions>
+        <portlet-application>
+          <portlet>
+            <application-ref>analytics</application-ref>
+            <portlet-ref>AnalyticsDashboardBreadcrumb</portlet-ref>
+          </portlet>
+          <title>Breadcrumb Analytics</title>
+          <access-permissions>Everyone</access-permissions>
+          <show-info-bar>false</show-info-bar>
+        </portlet-application>
+      </container>
+      <container cssClass="analyticsPageRow" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+        <access-permissions>Everyone</access-permissions>
+        <portlet-application>
+          <portlet>
+            <application-ref>analytics</application-ref>
+            <portlet-ref>AnalyticsPortlet</portlet-ref>
+            <preferences>
+              <preference>
+                <name>settings</name>
+                <value>
+                  {
+                    "filters": [
+                      {
+                        "field": "module",
+                        "type": "EQUAL",
+                        "valueString": "wallet"
+                      },
+                      {
+                        "field": "subModule",
+                        "type": "EQUAL",
+                        "valueString": "blockchain"
+                      }
+                    ],
+                    "aggregations": [
+                      {
+                        "field": "timestamp",
+                        "type": "DATE",
+                        "interval": "day",
+                        "useBounds": false,
+                        "sortDirection": "asc"
+                      },
+                      {
+                        "field": "timestamp",
+                        "type": "COUNT",
+                        "useBounds": false,
+                        "sortDirection": "desc"
+                      }
+                    ],
+                    "yAxisAggregation": {
+                      "field": "timestamp",
+                      "type": "COUNT",
+                      "useBounds": false,
+                      "sortDirection": "desc"
+                    },
+                    "xAxisAggregations": [
+                      {
+                        "field": "timestamp",
+                        "type": "DATE",
+                        "interval": "day",
+                        "useBounds": false,
+                        "sortDirection": "asc"
+                      }
+                    ],
+                    "multipleCharts": false,
+                    "chartType": "bar",
+                    "title": "Blockchain Calls"
+                  }
+                </value>
+              </preference>
+            </preferences>
+          </portlet>
+          <title>Blockchain Calls</title>
+          <access-permissions>Everyone</access-permissions>
+          <show-info-bar>false</show-info-bar>
+        </portlet-application>
+        <portlet-application>
+          <portlet>
+            <application-ref>analytics</application-ref>
+            <portlet-ref>AnalyticsPortlet</portlet-ref>
+            <preferences>
+              <preference>
+                <name>settings</name>
+                <value>
+                  {
+                    "filters": [
+                      {
+                        "field": "module",
+                        "type": "EQUAL",
+                        "valueString": "wallet"
+                      },
+                      {
+                        "field": "subModule",
+                        "type": "EQUAL",
+                        "valueString": "blockchain"
+                      }
+                    ],
+                    "aggregations": [
+                      {
+                        "field": "operation",
+                        "type": "TERMS",
+                        "useBounds": false,
+                        "sortDirection": "desc"
+                      },
+                      {
+                        "field": "operation",
+                        "type": "COUNT",
+                        "useBounds": false,
+                        "sortDirection": "desc"
+                      }
+                    ],
+                    "yAxisAggregation": {
+                      "field": "operation",
+                      "type": "COUNT",
+                      "useBounds": false,
+                      "sortDirection": "desc"
+                    },
+                    "xAxisAggregations": [
+                      {
+                        "field": "operation",
+                        "type": "TERMS",
+                        "useBounds": false,
+                        "sortDirection": "desc"
+                      }
+                    ],
+                    "multipleCharts": false,
+                    "chartType": "pie",
+                    "colors": [
+                      "#F97575",
+                      "#9EE4F5",
+                      "#98cc81",
+                      "#4273c8",
+                      "#cea6ac",
+                      "#bc99e7",
+                      "#9ee4f5",
+                      "#774ea9",
+                      "#ffa500",
+                      "#bed67e",
+                      "#0E100F",
+                      "#ffaacc"
+                    ],
+                    "title": "Blockchain Calls By Operation"
+                  }
+                </value>
+              </preference>
+            </preferences>
+          </portlet>
+          <title>Blockchain Calls By Operation</title>
+          <access-permissions>Everyone</access-permissions>
+          <show-info-bar>false</show-info-bar>
+        </portlet-application>
+      </container>
+    </container>
+  </page>
+</page-set>


### PR DESCRIPTION
This Feature will allow to compare Blockchain Access Provider with Local analytics system by collecting every call made on blockchain using analytics and adding a new page when the feature is enable to read easily blockchain calls analytics. This feature will be disabled by default. A special operation was made for getFilterChanges which is an internal operation called by Web3j. Knowing that we has a subscription verifier shceduled task, this operation has been added there with a modification to make this task executed with the same periodicity as polling interval.