### PR TITLE
fix: Fix Reward Computing Dates - MEED-572 - Meeds-io/meeds#308

### DIFF
--- a/wallet-webapps-reward/src/main/webapp/vue-app/components/RewardApp.vue
+++ b/wallet-webapps-reward/src/main/webapp/vue-app/components/RewardApp.vue
@@ -174,7 +174,7 @@ export default {
       return this.period?.timeZone || this.rewardSettings?.timeZone;
     },
     selectedDate() {
-      return this.period?.startDate.substring(0, 19) || new Date().toISOString().substring(0, 10);
+      return this.period?.startDate.substring(0, 10) || new Date().toISOString().substring(0, 10);
     },
     dateformat() {
       return this.timeZone && {

--- a/wallet-webapps-reward/src/main/webapp/vue-app/components/reward/SendRewardsTab.vue
+++ b/wallet-webapps-reward/src/main/webapp/vue-app/components/reward/SendRewardsTab.vue
@@ -428,6 +428,17 @@ export default {
         return 0;
       }
     },
+    selectedCompleteDateDate() {
+      if (this.selectedDate.length === 4) {
+        return `${this.selectedDate}-01-01`;
+      } else if (this.selectedDate.length === 7) {
+        return `${this.selectedDate}-01`;
+      } else if (this.selectedDate.length > 10) {
+        return this.selectedDate.substring(0, 10);
+      } else {
+        return this.selectedDate;
+      }
+    },
   },
   mounted() {
     $('.datePickerComponent input').on('click', (e) => {
@@ -447,21 +458,13 @@ export default {
         this.$refs.rewardDetails.open();
       }
     },
-    selectedDate() {
-      if (!this.selectedDate) {
+    selectedCompleteDateDate() {
+      if (!this.selectedCompleteDateDate) {
         return;
       }
       this.loading = true;
       this.lang = eXo.env.portal.language;
-      let selectedDate = this.selectedDate;
-      if (this.selectedDate.length === 4) {
-        selectedDate = `${this.selectedDate}-01-01`;
-      } else if (this.selectedDate.length === 7) {
-        selectedDate = `${this.selectedDate}-01`;
-      } else if (this.selectedDate.length > 10) {
-        selectedDate = this.selectedDate.substring(0, 10);
-      }
-      return this.$rewardService.getRewardDates(selectedDate)
+      return this.$rewardService.getRewardDates(this.selectedCompleteDateDate)
         .then((period) => {
           this.$emit('dates-changed', period);
         })
@@ -491,7 +494,7 @@ export default {
     sendRewards() {
       this.error = null;
       this.sendingRewards = true;
-      this.$rewardService.sendRewards(this.selectedDate)
+      this.$rewardService.sendRewards(this.selectedCompleteDateDate)
         .catch(e => {
           this.error = String(e);
         })


### PR DESCRIPTION
Prior to this change, the displayed dates on reward date picker displays the dates without timestamp. In addition, it displays the first day of the next week (at 00:00). This change will improve user experience by deleting 1 second from end date to display the last day of the week and to display the full date including the timezone that will be able to be changed by the administration in Configuration Tab.
