### PR TITLE
fix: Stabilize Unit Test random fail - Meeds-io/meeds#317

### DIFF
--- a/wallet-services/src/test/java/org/exoplatform/wallet/blockchain/service/EthereumClientConnectorTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/blockchain/service/EthereumClientConnectorTest.java
@@ -518,6 +518,7 @@ public class EthereumClientConnectorTest extends BaseWalletTest {
     service.setWeb3jService(web3jService);
     service.setWebSocketClient(webSocketClient);
     service.setListenerService(listenerService);
+    System.setProperty("exo.wallet.blockchain.permanentlyScan", "false");
   }
 
   private void setAsConnected() {


### PR DESCRIPTION
Prior to this change, when the Unit Test method orders execution changes, the method `testServiceStartWithPermanentListening` is executed before `testServiceStop`, the Ethereum blockchain connection is periodically checked and established. That's why sometimes the condition `assertFalse(service.isConnected())` fails. This change will stop the periodic connection check by changing the property `exo.wallet.blockchain.permanentlyScan` to its default value `false`.