### PR TITLE
fix : In reward administration, the request to compute reward is too long - EXO-60157 - meeds-io/meeds#330

### DIFF
--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-reward-services</artifactId>
   <name>eXo Add-on:: Wallet - Reward Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.80</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.79</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/plugin/GamificationRewardPlugin.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/plugin/GamificationRewardPlugin.java
@@ -18,6 +18,7 @@ package org.exoplatform.wallet.reward.plugin;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.PortalContainer;
@@ -35,7 +36,7 @@ public class GamificationRewardPlugin extends RewardPlugin {
   private static final String  GAMIFICATION_SERVICE_FQN     =
                                                         "org.exoplatform.addons.gamification.service.effective.GamificationService";
 
-  private static final String  FIND_USER_POINTS_METHOD_NAME = "findUserReputationScoreBetweenDate";
+  private static final String  FIND_USER_POINTS_METHOD_NAME = "findUsersReputationScoreBetweenDate";
 
   private ConfigurationManager configurationManager;
 
@@ -72,16 +73,21 @@ public class GamificationRewardPlugin extends RewardPlugin {
     if (method == null) {
       throw new IllegalStateException("Can't find gamification service method to retrieve user points");
     }
-    for (Long identityId : identityIds) {
-      long points = 0;
-      try {
-        points = (Long) method.invoke(getService(), String.valueOf(identityId), startDate, endDate);
-      } catch (Exception e) {
-        LOG.warn("Error getting gamification points for user with id {}", identityId, e);
-      }
-      earnedPoints.put(identityId, (double) points);
+    long start = System.currentTimeMillis();
+    Map<Long, Long> points = new HashMap<>();
+    try {
+      points = (Map<Long, Long>) method.invoke(getService(),
+                                               identityIds.stream().map(Object::toString).collect(Collectors.toList()),
+                                               startDate,
+                                               endDate);
+    } catch (Exception e) {
+      LOG.warn("Error getting gamification points for user with ids {}", identityIds, e);
     }
-    return earnedPoints;
+    LOG.info("Compute gamifications points for identityIds size={} take {} ms",
+             identityIds.size(),
+             System.currentTimeMillis() - start);
+
+    return points.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().doubleValue()));
   }
 
   private Method getMethod() {

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/plugin/KudosRewardPlugin.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/plugin/KudosRewardPlugin.java
@@ -18,6 +18,7 @@ package org.exoplatform.wallet.reward.plugin;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.configuration.ConfigurationManager;
@@ -33,7 +34,7 @@ public class KudosRewardPlugin extends RewardPlugin {
 
   private static final String  KUDOS_SERVICE_FQN             = "org.exoplatform.kudos.service.KudosService";
 
-  private static final String  COUNT_USERS_KUDOS_METHOD_NAME = "countKudosByPeriodAndReceiver";
+  private static final String  COUNT_USERS_KUDOS_METHOD_NAME = "countKudosByPeriodAndReceivers";
 
   private ConfigurationManager configurationManager;
 
@@ -68,16 +69,20 @@ public class KudosRewardPlugin extends RewardPlugin {
     if (method == null) {
       throw new IllegalStateException("Can't find kudos service method to retrieve user points");
     }
-    for (Long identityId : identityIds) {
-      long points = 0;
-      try {
-        points = (Long) method.invoke(getService(), identityId, startDateInSeconds, endDateInSeconds);
-      } catch (Exception e) {
-        LOG.warn("Error getting kudos count for user with id {}", identityId, e);
-      }
-      earnedPoints.put(identityId, (double) points);
+    long start = System.currentTimeMillis();
+    Map<Long, Long> points = new HashMap<>();
+    try {
+      points = (Map<Long, Long>) method.invoke(getService(),
+                                               identityIds.stream().collect(Collectors.toList()),
+                                               startDateInSeconds,
+                                               endDateInSeconds);
+    } catch (Exception e) {
+      LOG.warn("Error getting kudos count for users with ids {}", identityIds, e);
     }
-    return earnedPoints;
+    LOG.info("Compute kudo points for identityIds size={} take {} ms", identityIds.size(), System.currentTimeMillis() - start);
+
+    return points.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().doubleValue()));
+
   }
 
   private Method getMethod() {


### PR DESCRIPTION
Before this fix, with a lot of line in gamification history table, the request time for the "compute" request exceed the nginx timeout. This is due to the fact that scores are computed users by users. So there are 1 database request by reward plugin and by user. On tribe, 2*148 request. Each databse requests execute in near 800ms, so the request execution time is too long. This fix add change the compute to have one request per reward plugin, compute score for all users.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
