### PR TITLE
fix: Fix Reward computing when changing timezone - Meeds-io/meeds#333 - MEED-771

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardPeriod.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardPeriod.java
@@ -66,15 +66,19 @@ public class RewardPeriod implements Serializable {
   }
 
   public LocalDate getPeriodMedianDate() {
-    return LocalDate.ofInstant(Instant.ofEpochSecond((endDateInSeconds + startDateInSeconds) / 2), zoneId());
+    return LocalDate.ofInstant(Instant.ofEpochSecond(getPeriodMedianDateInSeconds()), zoneId());
+  }
+
+  public long getPeriodMedianDateInSeconds() {
+    return (endDateInSeconds + startDateInSeconds) / 2;
   }
 
   public String getStartDateFormatted(String lang) {
-    return formatTime(startDateInSeconds, lang);
+    return formatTime(startDateInSeconds, zoneId(), lang);
   }
 
   public String getEndDateFormatted(String lang) {
-    return formatTime(endDateInSeconds, lang);
+    return formatTime(endDateInSeconds, zoneId(), lang);
   }
 
 }

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/RewardUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/RewardUtils.java
@@ -21,7 +21,6 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -103,15 +102,15 @@ public class RewardUtils {
   private RewardUtils() {
   }
 
-  public static String formatTime(Object timeInSeconds, String lang) {
+  public static String formatTime(Object timeInSeconds, ZoneId zoneId, String lang) {
     Locale userLocale = StringUtils.isBlank(lang) ? Locale.getDefault() : new Locale(lang);
     LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(Long.parseLong(String.valueOf(timeInSeconds))),
-                                                     TimeZone.getDefault().toZoneId());
+                                                     zoneId);
     return dateTime.format(DATE_FORMATTER.withLocale(userLocale));
   }
 
-  public static LocalDateTime timeFromSeconds(long createdDate) {
-    return LocalDateTime.ofInstant(Instant.ofEpochSecond(createdDate), TimeZone.getDefault().toZoneId());
+  public static LocalDateTime timeFromSeconds(long createdDate, ZoneId zoneId) {
+    return LocalDateTime.ofInstant(Instant.ofEpochSecond(createdDate), zoneId);
   }
 
   public static long timeToSecondsAtDayStart(LocalDate date, ZoneId zoneId) {

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-reward-services</artifactId>
   <name>eXo Add-on:: Wallet - Reward Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.80</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.81</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProvider.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProvider.java
@@ -28,6 +28,7 @@ import org.exoplatform.commons.api.notification.model.ChannelKey;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.wallet.reward.service.RewardSettingsService;
 
 public class RewardSuccessTemplateProvider extends TemplateProvider {
 
@@ -41,9 +42,9 @@ public class RewardSuccessTemplateProvider extends TemplateProvider {
 
   private String                       mailTemplatePath = null;
 
-  public RewardSuccessTemplateProvider(PortalContainer container, InitParams initParams) {
+  public RewardSuccessTemplateProvider(PortalContainer container, RewardSettingsService rewardSettingsService, InitParams initParams) {
     super(initParams);
-    builder = new RewardSuccessTemplateBuilder(container, getChannelKey());
+    builder = new RewardSuccessTemplateBuilder(container, rewardSettingsService, getChannelKey());
 
     this.templateBuilders.put(PLUGIN_KEY, builder);
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
@@ -32,6 +32,7 @@ import static org.exoplatform.wallet.utils.WalletUtils.isUserRewardingAdmin;
 
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -587,17 +588,20 @@ public class WalletRewardReportService implements RewardReportService {
     if (StringUtils.isBlank(label)) {
       return "";
     }
+    RewardSettings rewardSettings = rewardSettingsService.getSettings();
     return label.replace("{0}", wallet.getName())
                 .replace("{1}", formatNumber(walletReward.getTokensToSend(), locale.getLanguage()))
                 .replace("{2}", contractDetail.getSymbol())
-                .replace("{3}", formatTime(periodOfTime.getStartDateInSeconds(), locale.getLanguage()))
-                .replace("{4}", formatTime(periodOfTime.getEndDateInSeconds() - 1, locale.getLanguage()));
+                .replace("{3}", formatTime(periodOfTime.getStartDateInSeconds(), rewardSettings.zoneId(), locale.getLanguage()))
+                .replace("{4}", formatTime(periodOfTime.getEndDateInSeconds() - 1, rewardSettings.zoneId(), locale.getLanguage()));
   }
 
   private String getTransactionMessage(WalletReward walletReward, ContractDetail contractDetail, RewardPeriod periodOfTime) {
     StringBuilder transactionMessage = new StringBuilder();
     Set<WalletPluginReward> walletRewardsByPlugin = walletReward.getRewards();
     Locale locale = getLocale(walletReward.getWallet());
+    RewardSettings rewardSettings = rewardSettingsService.getSettings();
+    ZoneId zoneId = rewardSettings.zoneId();
 
     for (WalletPluginReward walletPluginReward : walletRewardsByPlugin) {// NOSONAR
       String transactionMessagePart = null;
@@ -611,8 +615,8 @@ public class WalletRewardReportService implements RewardReportService {
                                       .replace("{2}", formatNumber(walletPluginReward.getPoints(), locale.getLanguage()))
                                       .replace("{3}", walletPluginReward.getPluginId())
                                       .replace("{4}", walletReward.getPoolName())
-                                      .replace("{5}", formatTime(periodOfTime.getStartDateInSeconds(), locale.getLanguage()))
-                                      .replace("{6}", formatTime(periodOfTime.getEndDateInSeconds() - 1, locale.getLanguage()));
+                                      .replace("{5}", formatTime(periodOfTime.getStartDateInSeconds(), zoneId, locale.getLanguage()))
+                                      .replace("{6}", formatTime(periodOfTime.getEndDateInSeconds() - 1, zoneId, locale.getLanguage()));
 
       } else {
         String label = getResourceBundleKey(locale, REWARD_TRANSACTION_NO_POOL_MESSAGE_KEY);
@@ -623,8 +627,8 @@ public class WalletRewardReportService implements RewardReportService {
                                       .replace("{1}", contractDetail.getSymbol())
                                       .replace("{2}", formatNumber(walletPluginReward.getPoints(), locale.getLanguage()))
                                       .replace("{3}", walletPluginReward.getPluginId())
-                                      .replace("{4}", formatTime(periodOfTime.getStartDateInSeconds(), locale.getLanguage()))
-                                      .replace("{5}", formatTime(periodOfTime.getEndDateInSeconds() - 1, locale.getLanguage()));
+                                      .replace("{4}", formatTime(periodOfTime.getStartDateInSeconds(), zoneId, locale.getLanguage()))
+                                      .replace("{5}", formatTime(periodOfTime.getEndDateInSeconds() - 1, zoneId, locale.getLanguage()));
       }
 
       transactionMessage.append(transactionMessagePart);

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardReportStorage.java
@@ -86,7 +86,7 @@ public class WalletRewardReportStorage {
   public RewardReport getRewardReport(RewardPeriodType periodType, LocalDate date, ZoneId zoneId) {
     RewardPeriod period = periodType.getPeriodOfTime(date, zoneId);
     WalletRewardPeriodEntity rewardPeriodEntity = rewardPeriodDAO.findRewardPeriodByTypeAndTime(periodType,
-                                                                                                period.getStartDateInSeconds());
+                                                                                                period.getPeriodMedianDateInSeconds());
     if (rewardPeriodEntity == null) {
       return null;
     }
@@ -114,7 +114,7 @@ public class WalletRewardReportStorage {
              period.getEndDateFormatted("en"));
 
     WalletRewardPeriodEntity rewardPeriodEntity = rewardPeriodDAO.findRewardPeriodByTypeAndTime(period.getRewardPeriodType(),
-                                                                                                period.getStartDateInSeconds());
+                                                                                                period.getPeriodMedianDateInSeconds());
     if (rewardPeriodEntity == null) {
       rewardPeriodEntity = new WalletRewardPeriodEntity();
     } else if (rewardPeriodEntity.getStatus() == RewardStatus.SUCCESS) {

--- a/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateBuilderTest.java
+++ b/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateBuilderTest.java
@@ -43,6 +43,7 @@ import org.exoplatform.wallet.model.reward.RewardReport;
 import org.exoplatform.wallet.model.reward.WalletReward;
 import org.exoplatform.wallet.model.transaction.TransactionDetail;
 import org.exoplatform.wallet.reward.BaseWalletRewardTest;
+import org.exoplatform.wallet.reward.service.WalletRewardSettingsService;
 
 public class RewardSuccessTemplateBuilderTest extends BaseWalletRewardTest {
 
@@ -54,7 +55,10 @@ public class RewardSuccessTemplateBuilderTest extends BaseWalletRewardTest {
     InitParams params = getParams();
     RewardSuccessNotificationPlugin plugin = new RewardSuccessNotificationPlugin(params);
 
-    RewardSuccessTemplateProvider templateProvider = new RewardSuccessTemplateProvider(container, params);
+    RewardSuccessTemplateProvider templateProvider =
+                                                   new RewardSuccessTemplateProvider(container,
+                                                                                     getService(WalletRewardSettingsService.class),
+                                                                                     params);
     templateProvider.setWebTemplatePath("jar:/template/RewardSuccessReward.gtmpl");
 
     NotificationContext ctx = NotificationContextImpl.cloneInstance();

--- a/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProviderTest.java
+++ b/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateProviderTest.java
@@ -27,6 +27,7 @@ import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.wallet.reward.BaseWalletRewardTest;
+import org.exoplatform.wallet.reward.service.WalletRewardSettingsService;
 
 public class RewardSuccessTemplateProviderTest extends BaseWalletRewardTest {
 
@@ -35,21 +36,27 @@ public class RewardSuccessTemplateProviderTest extends BaseWalletRewardTest {
    */
   @Test
   public void testGetTemplate() {
-    RewardSuccessTemplateProvider provider = new RewardSuccessTemplateProvider(container, getParams("MAIL_CHANNEL"));
+    RewardSuccessTemplateProvider provider = new RewardSuccessTemplateProvider(container,
+                                                                               getService(WalletRewardSettingsService.class),
+                                                                               getParams("MAIL_CHANNEL"));
     Map<PluginKey, String> templateFilePathConfigs = provider.getTemplateFilePathConfigs();
     assertNotNull(templateFilePathConfigs);
     assertEquals(1, templateFilePathConfigs.size());
     String template = templateFilePathConfigs.values().iterator().next();
     assertEquals(provider.getMailTemplatePath(), template);
 
-    provider = new RewardSuccessTemplateProvider(container, getParams("WEB_CHANNEL"));
+    provider = new RewardSuccessTemplateProvider(container,
+                                                 getService(WalletRewardSettingsService.class),
+                                                 getParams("WEB_CHANNEL"));
     templateFilePathConfigs = provider.getTemplateFilePathConfigs();
     assertNotNull(templateFilePathConfigs);
     assertEquals(1, templateFilePathConfigs.size());
     template = templateFilePathConfigs.values().iterator().next();
     assertEquals(provider.getWebTemplatePath(), template);
 
-    provider = new RewardSuccessTemplateProvider(container, getParams("PUSH_CHANNEL"));
+    provider = new RewardSuccessTemplateProvider(container,
+                                                 getService(WalletRewardSettingsService.class),
+                                                 getParams("PUSH_CHANNEL"));
     templateFilePathConfigs = provider.getTemplateFilePathConfigs();
     assertNotNull(templateFilePathConfigs);
     assertEquals(1, templateFilePathConfigs.size());


### PR DESCRIPTION
Prior to this change, when changing TimeZone settings in Rewards UI, the rewards sent of previous month are displayed in current Month. This is due to the fact that the start date was used to get the period entity of selected period of time. This change will simply use the median date to retrieve the period entity. This way, the correct period entity is retrieved interdependently from TimeZone shift.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
