### PR TITLE
feat: Remove walletApi portlet from wallet dynamic container - EXO-60319

### DIFF
--- a/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/dynamic-container-configuration.xml
+++ b/wallet-webapps-common/src/main/webapp/WEB-INF/conf/wallet/dynamic-container-configuration.xml
@@ -74,53 +74,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <init-params>
         <value-param>
           <name>priority</name>
-          <value>5</value>
-        </value-param>
-        <value-param>
-          <name>containerName</name>
-          <value>bottom-all-container</value>
-        </value-param>
-        <object-param>
-          <name>wallet-api-portlet</name>
-          <description></description>
-          <object type="org.exoplatform.commons.addons.PortletModel">
-            <field name="contentId">
-              <string>wallet/WalletAPI</string>
-            </field>
-            <field name="permissions">
-              <collection type="java.util.ArrayList">
-                <value>
-                <string>*:/platform/users</string>
-                </value>
-                <value>
-                  <string>*:/platform/externals</string>
-                </value>
-              </collection>
-            </field>
-            <field name="title">
-              <string>>Wallet api Portlet</string>
-            </field>
-            <field name="showInfoBar">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationState">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationMode">
-              <boolean>false</boolean>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
-      <name>addPlugin</name>
-      <set-method>addPlugin</set-method>
-      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
-      <description></description>
-      <init-params>
-        <value-param>
-          <name>priority</name>
           <value>1</value>
         </value-param>
         <value-param>


### PR DESCRIPTION
Prior to this change, Wallet api portlet was loaded in a dynamic container and presents in all pages without a current need and loads its amd modules in all pages including the web3 which affects the stream page perf because of loading a several unneeded js libraries. This PR removes this portlet as all it dependencies are already loaded in wallet page and where they are used.
