### PR TITLE
fix : Server do not start if we remove wallet addon - EXO-60702 - meeds-io/meeds#383

### DIFF
--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -72,10 +72,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
     <!-- swagger -->
     <dependency>
       <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
Before this fix, the wallet packaging contains the jar jackson-databind which is needed by other part of the platform. When the addon is uninstall because not needed, the jar is removed. In addition, this jar is not needed for wallet addon This fix remove the dependency on jackson-databind jar, so that the jar is no more in the packaging, and no more removed when uninstalling the addon

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
