### PR TITLE
feat: Overview Page eliminate decimals from balance and earnings display - MEED-1240 - Meeds-io/MIPs#10

### DIFF
--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-overview/components/WalletOverview.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-overview/components/WalletOverview.vue
@@ -55,7 +55,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <div
               :class="isOverviewDisplay ? 'display-1' : 'display-2'"
               class="text-color text-start font-weight-bold walletOverviewBalance">
-              {{ countReward.toFixed(2) }}
+              {{ isOverviewDisplay ? Math.trunc(countReward) : countReward.toFixed(2) }}
             </div>
           </template>
         </div>

--- a/wallet-webapps-common/src/main/webapp/vue-app/wallet-user-balance/components/WalletUserBalance.vue
+++ b/wallet-webapps-common/src/main/webapp/vue-app/wallet-user-balance/components/WalletUserBalance.vue
@@ -14,6 +14,10 @@ export default {
   data: () => ({
     wallet: null,
     contractDetails: null,
+    isOverviewDisplay: {
+      type: Boolean,
+      default: () => false,
+    },
   }),
   computed: {
     symbol() {
@@ -23,7 +27,7 @@ export default {
       return this.wallet?.tokenBalance;
     },
     balanceToDisplay() {
-      return this.balance?.toFixed(2);
+      return this.isOverviewDisplay ? Math.trunc(this.balance) : this.balance?.toFixed(2);
     }
   },
   created() {


### PR DESCRIPTION
this change is going to truncate and eliminates the decimals of the earnings and rewards display from the my earnings in overview page