### PR TITLE
Update ert-contract Version to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <properties>
     <!-- 3rd party libraries versions -->
     <org.exoplatform.social.version>6.5.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.wallet.ert-contract.version>1.3.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
     <org.exoplatform.platform-ui.version>6.5.x-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.analytics.version>1.4.x-SNAPSHOT</addon.exo.analytics.version>
+
+    <!-- ert-contract project version -->
+    <org.exoplatform.wallet.ert-contract.version>1.3.0</org.exoplatform.wallet.ert-contract.version>
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <properties>
     <!-- 3rd party libraries versions -->
     <org.exoplatform.social.version>6.5.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.wallet.ert-contract.version>1.4.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
+    <org.exoplatform.wallet.ert-contract.version>1.3.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
     <org.exoplatform.platform-ui.version>6.5.x-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.analytics.version>1.4.x-SNAPSHOT</addon.exo.analytics.version>
     <!-- Sonar properties -->


### PR DESCRIPTION
ert-contract project hasn't been changed for a while, thus it should be embedded and not released only when needed.