### PR TITLE
fix: Use Timed Lock instead of synchronized - MEED-1981

### DIFF
--- a/wallet-api/src/main/java/io/meeds/wallet/lock/Lock.java
+++ b/wallet-api/src/main/java/io/meeds/wallet/lock/Lock.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.wallet.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Lock {
+
+  String id() default "";
+
+  TimeUnit timeUnit();
+
+  int duration();
+
+}

--- a/wallet-api/src/main/java/io/meeds/wallet/lock/LockAspect.java
+++ b/wallet-api/src/main/java/io/meeds/wallet/lock/LockAspect.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.wallet.lock;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.StampedLock;
+
+import org.apache.commons.lang3.StringUtils;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+
+@Aspect
+public class LockAspect {
+
+  private static final Map<String, StampedLock> LOCKS = new HashMap<>();
+
+  @Around("execution(* *(..)) && @annotation(io.meeds.wallet.lock.Lock)")
+  public Object around(ProceedingJoinPoint point) throws Throwable { // NOSONAR
+    MethodSignature methodSignature = (MethodSignature) point.getSignature();
+    Method method = methodSignature.getMethod();
+    Lock annotation = method.getAnnotation(Lock.class);
+
+    String id = annotation.id();
+    if (StringUtils.isBlank(id)) {
+      id = method.toString();
+    }
+    StampedLock lock = LOCKS.computeIfAbsent(id, key -> new StampedLock());
+    long stamp = lock.tryWriteLock(annotation.duration(), annotation.timeUnit());
+    try {
+      return point.proceed();
+    } finally {
+      lock.unlock(stamp);
+    }
+  }
+
+}

--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumClientConnector.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumClientConnector.java
@@ -80,6 +80,7 @@ import org.exoplatform.wallet.model.transaction.TransactionDetail;
 import org.exoplatform.wallet.statistic.ExoWalletStatistic;
 import org.exoplatform.wallet.statistic.ExoWalletStatisticService;
 
+import io.meeds.wallet.lock.Lock;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.UndeliverableException;
@@ -206,7 +207,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
    * @param transactionHash transaction hash to retrieve
    * @return Web3j Transaction object
    */
-  public synchronized Transaction getTransaction(String transactionHash) {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  public Transaction getTransaction(String transactionHash) {
     return transactionFutureCache.get(null, StringUtils.lowerCase(transactionHash));
   }
 
@@ -229,7 +231,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
    * @param transactionHash transaction hash to retrieve
    * @return Web3j Transaction receipt object
    */
-  public synchronized TransactionReceipt getTransactionReceipt(String transactionHash) {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  public TransactionReceipt getTransactionReceipt(String transactionHash) {
     return receiptFutureCache.get(null, StringUtils.lowerCase(transactionHash));
   }
 
@@ -403,12 +406,14 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
     return parameters;
   }
 
-  public synchronized Future<Disposable> renewTransactionListeningSubscription(long lastWatchedBlockNumber) {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  public Future<Disposable> renewTransactionListeningSubscription(long lastWatchedBlockNumber) {
     this.setLastWatchedBlockNumber(lastWatchedBlockNumber);
     return renewTransactionListeningSubscription();
   }
 
-  public synchronized void cancelTransactionListeningToBlockchain() {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  public void cancelTransactionListeningToBlockchain() {
     stopListeningToBlockchain();
     stopPeriodicConnectionVerifier();
   }
@@ -453,7 +458,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
     return connect(false);
   }
 
-  protected synchronized boolean connect(boolean periodicCheck) throws Exception { // NOSONAR
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  protected boolean connect(boolean periodicCheck) throws Exception { // NOSONAR
     if (periodicCheck) {
       startPeriodicConnectionVerifier();
     }
@@ -554,7 +560,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
     return connectionVerifierFuture;
   }
 
-  protected synchronized void checkSubscription() {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  protected void checkSubscription() {
     if (this.listeningToBlockchain && !this.subscriptionInProgress) {
       renewSubscriptionWhenDisposed();
     }
@@ -626,7 +633,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
     }
   }
 
-  protected synchronized void stopListeningToBlockchain() {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  protected void stopListeningToBlockchain() {
     try {
       if (this.ethFilterSubscribtion != null && !this.ethFilterSubscribtion.isDisposed()) {
         LOG.info("Close mined contract transactions subscription");
@@ -646,7 +654,8 @@ public class EthereumClientConnector implements ExoWalletStatisticService, Start
     this.ethFilterSubscribtion.dispose();
   }
 
-  private synchronized void startPeriodicConnectionVerifier() {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  protected void startPeriodicConnectionVerifier() {
     if (connectionVerifierFuture == null) {
       LOG.info("Start periodic WebSocket endpoint connection status check");
       // Blockchain connection verifier

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
@@ -53,6 +53,7 @@ import static org.exoplatform.wallet.utils.WalletUtils.toJsonString;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.picocontainer.Startable;
@@ -83,6 +84,8 @@ import org.exoplatform.wallet.model.settings.NetworkSettings;
 import org.exoplatform.wallet.model.settings.UserSettings;
 import org.exoplatform.wallet.model.settings.WalletSettings;
 import org.exoplatform.wallet.model.transaction.FundsRequest;
+
+import io.meeds.wallet.lock.Lock;
 
 /**
  * A storage service to save/load information used by users and spaces wallets
@@ -476,7 +479,8 @@ public class WalletServiceImpl implements WalletService, Startable {
     }
   }
 
-  private synchronized double getGasPriceBlocking() throws IOException {
+  @Lock(duration = 30, timeUnit = TimeUnit.SECONDS)
+  private double getGasPriceBlocking() throws IOException {
     if (dynamicGasPrice == 0 || (System.currentTimeMillis() - dynamicGasPriceLastUpdateTime) > dynamicGasPriceUpdateInterval) {
       double gasPrice = getBlockchainTransactionService().getGasPrice();
       setGasPrice(gasPrice);


### PR DESCRIPTION
Prior to this change, when the connection to blockchain operation takes a lot of time, all other operations are blocked until the operation in progress finishes. This change will modify the usage of 'synchronized' in favor of a 'StampedLock'.