### PR TITLE
feat: Enable Push notifications Channel when addon installed - MEED-2062 - Meeds-io/meeds#900

### DIFF
--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/notification-configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/notification-configuration.xml
@@ -221,7 +221,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>push.channel.wallet.template</name>
       <set-method>registerTemplateProvider</set-method>
       <type>org.exoplatform.wallet.notification.provider.MobilePushTemplateProvider</type>
@@ -254,7 +254,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>push.channel.wallet.reward.template</name>
       <set-method>registerTemplateProvider</set-method>
       <type>org.exoplatform.wallet.reward.notification.RewardSuccessTemplateProvider</type>


### PR DESCRIPTION
Prior to this change, Push notification channel was configured even when the addon isn't installed. This change will add this configuration only when push-notifications addon is added.