### PR TITLE
feat: Allow to send initial funds to First initialization of Metamask Wallet - MEED-2208 - Meeds-io/MIPs#50

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
@@ -82,7 +82,10 @@ public class ExoWalletStatisticAspect {
     } finally {
       long duration = System.currentTimeMillis() - startTime;
       try {
-        Map<String, Object> parameters = statisticService.getStatisticParameters(operation, result, point.getArgs());
+        Map<String, Object> parameters = statisticService == null ? null
+                                                                  : statisticService.getStatisticParameters(operation,
+                                                                                                            result,
+                                                                                                            point.getArgs());
         if (parameters != null) {
           if (local) {
             put(parameters, LOCAL_SERVICE, service);
@@ -109,7 +112,9 @@ public class ExoWalletStatisticAspect {
               put(parameters, STATUS_CODE, "200");
             }
           }
-          addStatisticEntry(parameters);
+          if (ExoContainer.hasProfile("analytics")) {
+            addStatisticEntry(parameters);
+          }
         }
       } catch (Throwable e) {
         LOG.warn("Error adding statistic log entry in method '{}' for statistic type '{}'", method.getName(), operation, e);

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-services</artifactId>
   <name>eXo Add-on:: Wallet - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.62</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import javax.persistence.TypedQuery;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.entity.WalletEntity;
 
@@ -38,7 +40,7 @@ public class WalletAccountDAO extends GenericDAOJPAImpl<WalletEntity, Long> {
   public WalletEntity findByAddress(String address) {
     TypedQuery<WalletEntity> query = getEntityManager().createNamedQuery("Wallet.findByAddress",
                                                                          WalletEntity.class);
-    query.setParameter("address", address);
+    query.setParameter("address", StringUtils.lowerCase(address));
     List<WalletEntity> resultList = query.getResultList();
     return resultList == null || resultList.isEmpty() ? null : resultList.get(0);
   }

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
@@ -32,7 +32,7 @@ import org.exoplatform.wallet.model.WalletType;
 @ExoEntity
 @DynamicUpdate
 @Table(name = "ADDONS_WALLET_ACCOUNT")
-@NamedQuery(name = "Wallet.findByAddress", query = "SELECT w FROM Wallet w WHERE w.address = :address")
+@NamedQuery(name = "Wallet.findByAddress", query = "SELECT w FROM Wallet w WHERE LOWER(w.address) = :address")
 public class WalletEntity implements Serializable {
   private static final long                       serialVersionUID = -1622032986992776281L;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
@@ -108,7 +108,7 @@ public class WalletStorage {
    * @return {@link Wallet} details identified by address
    */
   public Wallet getWalletByAddress(String address, String contractAddress) {
-    WalletEntity walletEntity = walletAccountDAO.findByAddress(address.toLowerCase());
+    WalletEntity walletEntity = walletAccountDAO.findByAddress(address);
     if (walletEntity == null) {
       return null;
     }
@@ -319,7 +319,7 @@ public class WalletStorage {
     String address = walletBackup.getAddress();
 
     WalletEntity walletEntity = walletAccountDAO.find(walletId);
-    walletEntity.setAddress(address);
+    walletEntity.setAddress(StringUtils.lowerCase(address));
     walletEntity.setProvider(WalletProvider.INTERNAL_WALLET);
     walletEntity.setInitializationState(WalletState.MODIFIED);
     walletAccountDAO.update(walletEntity);
@@ -351,7 +351,7 @@ public class WalletStorage {
       }
     }
 
-    walletEntity.setAddress(newAddress);
+    walletEntity.setAddress(StringUtils.lowerCase(newAddress));
     walletEntity.setProvider(provider);
     if(walletEntity.getInitializationState() == WalletState.DELETED){
       walletEntity.setInitializationState(WalletState.MODIFIED);
@@ -389,7 +389,7 @@ public class WalletStorage {
       walletEntity = new WalletEntity();
     }
     walletEntity.setId(wallet.getTechnicalId());
-    walletEntity.setAddress(wallet.getAddress().toLowerCase());
+    walletEntity.setAddress(StringUtils.lowerCase(wallet.getAddress()));
     walletEntity.setEnabled(wallet.isEnabled());
     walletEntity.setInitializationState(WalletState.valueOf(wallet.getInitializationState()));
     walletEntity.setPassPhrase(wallet.getPassPhrase());

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAccountServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletAccountServiceTest.java
@@ -16,14 +16,9 @@
  */
 package org.exoplatform.wallet.service;
 
+import static org.exoplatform.wallet.utils.WalletUtils.NEW_ADDRESS_ASSOCIATED_EVENT;
 import static org.exoplatform.wallet.utils.WalletUtils.WALLET_MODIFIED_EVENT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -40,12 +35,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
+import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
@@ -121,6 +120,33 @@ public class WalletAccountServiceTest extends BaseWalletTest {
 
     String addressTest = storedWallet.getAddress();
     assertEquals("Unexpected wallet address", StringUtils.lowerCase(WALLET_ADDRESS_1), StringUtils.lowerCase(addressTest));
+  }
+
+  @Test
+  public void testSaveWallet() throws IllegalAccessException {
+    String walletAddress = "0x11111111155511111111111111111111111111";
+    WalletAccountService walletAccountService = getService(WalletAccountService.class);
+    Wallet userWallet =
+                      walletAccountService.createWalletInstance(WalletProvider.METAMASK, walletAddress, CURRENT_USER_IDENTITY_ID);
+
+    AtomicInteger increment = new AtomicInteger(0);
+    getService(ListenerService.class).addListener(NEW_ADDRESS_ASSOCIATED_EVENT, new Listener<Object, String>() {
+      @Override
+      public void onEvent(Event<Object, String> event) throws Exception {
+        increment.incrementAndGet();
+      }
+    });
+
+    userWallet = walletAccountService.saveWallet(userWallet, true);
+    entitiesToClean.add(userWallet);
+
+    Wallet storedWallet = walletAccountService.getWalletByAddress(walletAddress);
+    assertNotNull(storedWallet);
+    assertNotNull(storedWallet.getPassPhrase());
+    assertEquals("Unexpected wallet address",
+                 StringUtils.lowerCase(walletAddress),
+                 StringUtils.lowerCase(storedWallet.getAddress()));
+    assertEquals(1, increment.get());
   }
 
   /**
@@ -755,7 +781,7 @@ public class WalletAccountServiceTest extends BaseWalletTest {
 
     assertNotNull(wallet);
     assertEquals(WalletProvider.METAMASK.name(), wallet.getProvider());
-    assertEquals(walletAddress, wallet.getAddress());
+    assertEquals(StringUtils.lowerCase(walletAddress), wallet.getAddress());
     assertTrue(wallet.isBackedUp());
     assertTrue(wallet.getIsInitialized());
     assertEquals(WalletState.INITIALIZED.name(), wallet.getInitializationState());
@@ -763,7 +789,7 @@ public class WalletAccountServiceTest extends BaseWalletTest {
     walletAccountService.switchToInternalWallet(wallet.getTechnicalId());
     wallet = walletAccountService.getWalletByIdentityId(CURRENT_USER_IDENTITY_ID);
     assertNotNull(wallet);
-    assertEquals(internalWalletAddress, wallet.getAddress());
+    assertEquals(StringUtils.lowerCase(internalWalletAddress), wallet.getAddress());
     assertEquals(WalletProvider.INTERNAL_WALLET.name(), wallet.getProvider());
     assertTrue(wallet.isBackedUp());
     assertTrue(wallet.getIsInitialized());
@@ -796,6 +822,7 @@ public class WalletAccountServiceTest extends BaseWalletTest {
     WalletAccountServiceImpl walletAccountService = new WalletAccountServiceImpl(mock(PortalContainer.class),
                                                                                  accountStorage,
                                                                                  mock(AddressLabelStorage.class),
+                                                                                 mock(SettingService.class),
                                                                                  mock(InitParams.class));
     walletAccountService.setTokenAdminService(tokenAdminService);
     walletAccountService.setListenerService(listenerService);


### PR DESCRIPTION
Prior to this change, when initializing Metamask wallet for the first time for a user, the initial funds wasn't sent to user. This change will allow to send initial funds for a given user for the first time only by triggering the generic event 'exo.wallet.addressAssociation.new' which was triggered only when the wallet is initialized with a Browser Wallet.