### PR TITLE
fix: Fix Initializing Wallet Upcoming Reward Overview - MEED-2311 - Meeds-io/meeds#1012

### DIFF
--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/weekly-earnings/components/WeeklyEarnings.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/weekly-earnings/components/WeeklyEarnings.vue
@@ -58,10 +58,8 @@ export default {
     }
   },
   created() {
-    Promise.all([
-      this.init(),
-      this.refreshRewards(),
-    ]).finally(() => this.loading = false);
+    this.init()
+      .finally(() => this.loading = false);
   },
   methods: {
     init() {
@@ -72,19 +70,19 @@ export default {
             this.contractDetails = Object.assign({},window.walletSettings.contractDetail); 
           }
           return this.$nextTick();
-        });
+        })
+        .then(() => this.refreshRewards());
     },
     refreshRewards() {
-      return computeRewardsByUser(this.selectedDate)
+      return this.wallet?.address?.length && computeRewardsByUser(this.selectedDate)
         .then(rewardReport => {
           if (rewardReport) {
-            for (const reward of rewardReport.rewards) {
-              if (reward.wallet.address.toUpperCase() === this.wallet.address.toUpperCase()) {
-                this.weeklyReward = reward.tokensToSend;
-              } 
-            }
+            const walletAddress = this.wallet.address.toUpperCase();
+            const walletReward = rewardReport.rewards.find(reward => reward.wallet.address.toUpperCase() === walletAddress);
+            this.weeklyReward = walletReward?.tokensToSend || 0;
+          } else {
+            this.weeklyReward = 0;
           }
-          return this.$nextTick();
         });
     },
     openDrawer() {


### PR DESCRIPTION
Prior to this change, when the Wallet Settings Operation is slower than Wallet Rewarding Computing, [a race condition issue was sometimes and randomly observed](https://github.com/Meeds-io/wallet/blob/1e36fb8e52cc25d1a936dbc9a958f92ddc2786bd/wallet-webapps-common/src/main/webapp/vue-app/weekly-earnings/components/weeklyEarnings.vue#L60-L61) (not observed on Meeds Builders since 6 months but on other environments). This change will make the rewarding computing made after wallet intialization instead of parallel execution of both operations.