### PR TITLE
feat: Allow to start even if wallet admin key is not ok - Meeds-io/meeds#1028

### DIFF
--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
@@ -145,6 +145,8 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
 
   private long                                    adminBlockchainNonceLastUpdate;
 
+  private boolean                                 checkAdminKey = true;
+
   private FutureCache<String, BigInteger, Object> tokenBalanceFutureCache                 = null;
 
   private FutureCache<String, BigInteger, Object> etherBalanceFutureCache                 = null;
@@ -187,6 +189,7 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
         return;
       }
       this.adminPrivateKey = System.getProperty("exo.wallet.admin.privateKey", null);
+      this.checkAdminKey = !"false".equals(System.getProperty("exo.wallet.admin.checkAdminKey"));
       this.configuredContractAddress = settings.getContractAddress();
       this.websocketURL = getWebsocketURL();
       this.networkId = getNetworkId();
@@ -515,7 +518,7 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
     Wallet adminWallet = getAccountService().getAdminWallet();
     if (adminWallet == null || StringUtils.isBlank(adminWallet.getAddress())) {
       createAdminWalletAsync();
-    } else {
+    } else if (this.checkAdminKey){
       checkAdminWallet();
     }
   }


### PR DESCRIPTION
Add the possibility to bypass the wallet admin verification at startup.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
