### PR TITLE
feat: Add Wallet Initialization Gamification Trigger - MEED-2208 - Meeds-io/MIPs#50

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/statistic/ExoWalletStatisticAspect.java
@@ -82,7 +82,10 @@ public class ExoWalletStatisticAspect {
     } finally {
       long duration = System.currentTimeMillis() - startTime;
       try {
-        Map<String, Object> parameters = statisticService.getStatisticParameters(operation, result, point.getArgs());
+        Map<String, Object> parameters = statisticService == null ? null
+                                                                  : statisticService.getStatisticParameters(operation,
+                                                                                                            result,
+                                                                                                            point.getArgs());
         if (parameters != null) {
           if (local) {
             put(parameters, LOCAL_SERVICE, service);
@@ -109,7 +112,9 @@ public class ExoWalletStatisticAspect {
               put(parameters, STATUS_CODE, "200");
             }
           }
-          addStatisticEntry(parameters);
+          if (ExoContainer.hasProfile("analytics")) {
+            addStatisticEntry(parameters);
+          }
         }
       } catch (Throwable e) {
         LOG.warn("Error adding statistic log entry in method '{}' for statistic type '{}'", method.getName(), operation, e);

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpSession;
 
@@ -102,10 +101,12 @@ public class WalletUtils {
   }
 
   @SuppressWarnings("all")
-  public static final char[]                          SIMPLE_CHARS                             = new char[] { 'A', 'B', 'C', 'D',
+  public static final char[]                          SIMPLE_CHARS                             = new char[] {
+      'A', 'B', 'C', 'D',
       'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c',
       'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1',
-      '2', '3', '4', '5', '6', '7', '8', '9' };
+      '2', '3', '4', '5', '6', '7', '8', '9'
+  };
 
   public static final String                          COMETD_CHANNEL                           = "/eXo/Application/Addons/Wallet";
 
@@ -167,6 +168,8 @@ public class WalletUtils {
   public static final String                          WALLET_USER_TRANSACTION_NAME             = "WALLET_USER_TRANSACTION";
 
   public static final String                          WALLET_BROWSER_PHRASE_NAME               = "WALLET_BROWSER_PHRASE";
+
+  public static final String                          WALLET_INITIALIZED_SETTING_PARAM         = "WALLET_INITIALIZED";
 
   public static final String                          ADMIN_KEY_PARAMETER                      = "admin.wallet.key";
 
@@ -365,6 +368,23 @@ public class WalletUtils {
 
   public static final String                          LOGIN_MESSAGE_ATTRIBUTE_NAME             = "login_message";
 
+  public static final String                          GAMIFICATION_BROADCAST_ACTION_EVENT      =
+                                                                                          "exo.gamification.generic.action";
+
+  public static final String                          GAMIFICATION_EVENT_ID                    = "eventId";
+
+  public static final String                          GAMIFICATION_EARNER_ID                   = "senderId";
+
+  public static final String                          GAMIFICATION_RECEIVER_ID                 = "receiverId";
+
+  public static final String                          GAMIFICATION_OBJECT_ID                   = "objectId";
+
+  public static final String                          GAMIFICATION_OBJECT_TYPE                 = "objectType";
+
+  public static final String                          GAMIFICATION_WALLET_OBJECT_TYPE          = "wallet";
+
+  public static final String                          GAMIFICATION_CREATE_WALLET_EVENT         = "createWallet";
+
   public static final Random                          Random                                   = new Random();
 
   public static String                                blockchainUrlSuffix                      = null;                                 // NOSONAR
@@ -394,7 +414,7 @@ public class WalletUtils {
         } else if (StringUtils.isBlank(excludedId)) {
           return Arrays.asList(managers);
         } else {
-          return Arrays.stream(managers).filter(member -> !excludedId.equals(member)).collect(Collectors.toList());
+          return Arrays.stream(managers).filter(member -> !excludedId.equals(member)).toList();
         }
       }
     } else if (WalletType.isUser(wallet.getType())) {
@@ -643,9 +663,9 @@ public class WalletUtils {
   /**
    * Return true if user can access wallet detailed information
    * 
-   * @param wallet wallet details to check
-   * @param currentUser user accessing wallet details
-   * @return true if has access, else false
+   * @param  wallet      wallet details to check
+   * @param  currentUser user accessing wallet details
+   * @return             true if has access, else false
    */
   public static boolean canAccessWallet(Wallet wallet, String currentUser) {
     if (StringUtils.isBlank(currentUser)) {
@@ -938,11 +958,7 @@ public class WalletUtils {
     case ETHER_FUNC_SEND_FUNDS:
       parameters.put("amount_ether", transactionDetail.getValue());
       break;
-    case CONTRACT_FUNC_TRANSFORMTOVESTED:
-    case CONTRACT_FUNC_TRANSFERFROM:
-    case CONTRACT_FUNC_TRANSFER:
-    case CONTRACT_FUNC_APPROVE:
-    case CONTRACT_FUNC_REWARD:
+    case CONTRACT_FUNC_TRANSFORMTOVESTED, CONTRACT_FUNC_TRANSFERFROM, CONTRACT_FUNC_TRANSFER, CONTRACT_FUNC_APPROVE, CONTRACT_FUNC_REWARD:
       parameters.put("amount_token", transactionDetail.getContractAmount());
       break;
     case CONTRACT_FUNC_ADDADMIN:
@@ -978,11 +994,11 @@ public class WalletUtils {
    * Format Wallet Balance amount in currency format, without currency symbol
    * and switch user locale.
    * 
-   * @param balance amount to format
-   * @param locale designated locale to display balance
-   * @param simplified if true, the fractions will be ignored when the balance
-   *          is greater than 100.
-   * @return formatted balance in user locale
+   * @param  balance    amount to format
+   * @param  locale     designated locale to display balance
+   * @param  simplified if true, the fractions will be ignored when the balance
+   *                      is greater than 100.
+   * @return            formatted balance in user locale
    */
   public static final String formatBalance(double balance, Locale locale, boolean simplified) {
     // Avoid to display fractions when the amount of balance is big

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-services</artifactId>
   <name>eXo Add-on:: Wallet - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.62</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import javax.persistence.TypedQuery;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.entity.WalletEntity;
 
@@ -38,7 +40,7 @@ public class WalletAccountDAO extends GenericDAOJPAImpl<WalletEntity, Long> {
   public WalletEntity findByAddress(String address) {
     TypedQuery<WalletEntity> query = getEntityManager().createNamedQuery("Wallet.findByAddress",
                                                                          WalletEntity.class);
-    query.setParameter("address", address);
+    query.setParameter("address", StringUtils.lowerCase(address));
     List<WalletEntity> resultList = query.getResultList();
     return resultList == null || resultList.isEmpty() ? null : resultList.get(0);
   }

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
@@ -32,7 +32,7 @@ import org.exoplatform.wallet.model.WalletType;
 @ExoEntity
 @DynamicUpdate
 @Table(name = "ADDONS_WALLET_ACCOUNT")
-@NamedQuery(name = "Wallet.findByAddress", query = "SELECT w FROM Wallet w WHERE w.address = :address")
+@NamedQuery(name = "Wallet.findByAddress", query = "SELECT w FROM Wallet w WHERE LOWER(w.address) = :address")
 public class WalletEntity implements Serializable {
   private static final long                       serialVersionUID = -1622032986992776281L;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListener.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListener.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wallet.listener;
+
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_BROADCAST_ACTION_EVENT;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_CREATE_WALLET_EVENT;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_EARNER_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_EVENT_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_OBJECT_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_OBJECT_TYPE;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_RECEIVER_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_WALLET_OBJECT_TYPE;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.wallet.model.Wallet;
+
+@Asynchronous
+public class GamificationWalletInitializationListener extends Listener<Object, String> {
+
+  private ListenerService listenerService;
+
+  public GamificationWalletInitializationListener(ListenerService listenerService) {
+    this.listenerService = listenerService;
+  }
+
+  @Override
+  public void onEvent(Event<Object, String> event) throws Exception {
+    Wallet wallet = (Wallet) event.getSource();
+    Map<String, String> gam = new HashMap<>();
+    gam.put(GAMIFICATION_EVENT_ID, GAMIFICATION_CREATE_WALLET_EVENT);
+    gam.put(GAMIFICATION_EARNER_ID, String.valueOf(wallet.getTechnicalId()));
+    gam.put(GAMIFICATION_RECEIVER_ID, String.valueOf(wallet.getTechnicalId()));
+    gam.put(GAMIFICATION_OBJECT_TYPE, GAMIFICATION_WALLET_OBJECT_TYPE);
+    gam.put(GAMIFICATION_OBJECT_ID, wallet.getAddress());
+    listenerService.broadcast(GAMIFICATION_BROADCAST_ACTION_EVENT, gam, null);
+  }
+
+}

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/WalletStorage.java
@@ -108,7 +108,7 @@ public class WalletStorage {
    * @return {@link Wallet} details identified by address
    */
   public Wallet getWalletByAddress(String address, String contractAddress) {
-    WalletEntity walletEntity = walletAccountDAO.findByAddress(address.toLowerCase());
+    WalletEntity walletEntity = walletAccountDAO.findByAddress(address);
     if (walletEntity == null) {
       return null;
     }
@@ -319,7 +319,7 @@ public class WalletStorage {
     String address = walletBackup.getAddress();
 
     WalletEntity walletEntity = walletAccountDAO.find(walletId);
-    walletEntity.setAddress(address);
+    walletEntity.setAddress(StringUtils.lowerCase(address));
     walletEntity.setProvider(WalletProvider.INTERNAL_WALLET);
     walletEntity.setInitializationState(WalletState.MODIFIED);
     walletAccountDAO.update(walletEntity);
@@ -351,7 +351,7 @@ public class WalletStorage {
       }
     }
 
-    walletEntity.setAddress(newAddress);
+    walletEntity.setAddress(StringUtils.lowerCase(newAddress));
     walletEntity.setProvider(provider);
     if(walletEntity.getInitializationState() == WalletState.DELETED){
       walletEntity.setInitializationState(WalletState.MODIFIED);
@@ -389,7 +389,7 @@ public class WalletStorage {
       walletEntity = new WalletEntity();
     }
     walletEntity.setId(wallet.getTechnicalId());
-    walletEntity.setAddress(wallet.getAddress().toLowerCase());
+    walletEntity.setAddress(StringUtils.lowerCase(wallet.getAddress()));
     walletEntity.setEnabled(wallet.isEnabled());
     walletEntity.setInitializationState(WalletState.valueOf(wallet.getInitializationState()));
     walletEntity.setPassPhrase(wallet.getPassPhrase());

--- a/wallet-services/src/test/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListenerTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListenerTest.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wallet.listener;
+
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_BROADCAST_ACTION_EVENT;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_CREATE_WALLET_EVENT;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_EARNER_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_EVENT_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_OBJECT_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_OBJECT_TYPE;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_RECEIVER_ID;
+import static org.exoplatform.wallet.utils.WalletUtils.GAMIFICATION_WALLET_OBJECT_TYPE;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.wallet.model.Wallet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GamificationWalletInitializationListenerTest {
+
+  private static final String   WALLET_ADDRESS = "0x123...7FED";
+
+  private static final long     IDENTITY_ID    = 555l;
+
+  @Mock
+  private ListenerService       listenerService;
+
+  @Mock
+  private Wallet                wallet;
+
+  @Mock
+  private Event<Object, String> event;
+
+  @Test
+  public void testInitializeWallet() throws Exception {
+    GamificationWalletInitializationListener gamificationListener = new GamificationWalletInitializationListener(listenerService);
+    when(wallet.getTechnicalId()).thenReturn(IDENTITY_ID);
+    when(wallet.getAddress()).thenReturn(WALLET_ADDRESS);
+    when(event.getSource()).thenReturn(wallet);
+
+    gamificationListener.onEvent(event);
+
+    verify(listenerService,
+           times(1)).broadcast(eq(GAMIFICATION_BROADCAST_ACTION_EVENT),
+                               argThat((Map<String, String> source) -> source.get(GAMIFICATION_EVENT_ID)
+                                                                             .equals(GAMIFICATION_CREATE_WALLET_EVENT)
+                                   && source.get(GAMIFICATION_EARNER_ID)
+                                            .equals(String.valueOf(IDENTITY_ID))
+                                   && source.get(GAMIFICATION_RECEIVER_ID)
+                                            .equals(String.valueOf(IDENTITY_ID))
+                                   && source.get(GAMIFICATION_OBJECT_TYPE)
+                                            .equals(GAMIFICATION_WALLET_OBJECT_TYPE)
+                                   && source.get(GAMIFICATION_OBJECT_ID)
+                                            .equals(WALLET_ADDRESS)),
+                               eq(null));
+
+  }
+
+}

--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -33,5 +33,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <import>war:/conf/wallet/wallet-portal-configuration.xml</import>
   <import profiles="app-center">war:/conf/wallet/app-center-configuration.xml</import>
   <import>war:/conf/wallet/navigation-categories-configuration.xml</import>
+  <import profiles="gamification">war:/conf/wallet/gamification-configuration.xml</import>
 
 </configuration>

--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/gamification-configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/gamification-configuration.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>exo.wallet.addressAssociation.new</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.wallet.listener.GamificationWalletInitializationListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>io.meeds.gamification.service.RuleRegistry</target-component>
+    <component-plugin>
+      <name>rule.initializeWallet</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.gamification.plugin.RuleConfigPlugin</type>
+      <init-params>
+        <value-param>
+          <name>rule-event</name>
+          <value>createWallet</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/wallet-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -416,6 +416,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </depends>
   </module>
 
+  <module>
+    <name>engagementCenterActionsWalletExtensions</name>
+    <load-group>engagement-center-user-actions</load-group>
+    <script>
+      <path>/js/engagementCenterExtensions.bundle.js</path>
+    </script>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
   <!-- TODO : Deprecated to use eChart instead  -->
   <module>
     <name>vueChart</name>

--- a/wallet-webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/wallet-webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -1,0 +1,14 @@
+const userActions = ['createWallet'];
+export function init() {
+  extensionRegistry.registerExtension('engagementCenterActions', 'user-actions', {
+    type: 'wallet',
+    options: {
+      rank: 50,
+      icon: 'fas fa-wallet',
+      match: (actionLabel) => userActions.includes(actionLabel),
+      getLink: (realization) => {
+        Vue.prototype.$set(realization, 'link', `${eXo.env.portal.context}/${eXo.env.portal.portalName}/wallet`);
+      }
+    },
+  });
+}

--- a/wallet-webapps/webpack.prod.js
+++ b/wallet-webapps/webpack.prod.js
@@ -29,6 +29,7 @@ const config = merge(webpackCommonConfig, {
     walletSettings: './src/main/webapp/vue-app/wallet-common/wallet-settings/main.js',
     walletOverview: './src/main/webapp/vue-app/wallet-common/wallet-overview/main.js',
     rewardApp: './src/main/webapp/vue-app/wallet-reward/main.js',
+    engagementCenterExtensions: './src/main/webapp/vue-app/engagementCenterExtensions/extensions.js'
   },
   output: {
     path: path.join(__dirname, 'target/wallet/'),


### PR DESCRIPTION
* This change will introduce a new Trigger to gamification for wallet first creation.
* Allow to send initial funds to First initialization of Metamask Wallet Prior to this change, when initializing Metamask wallet for the first time for a user, the initial funds wasn't sent to user. This change will allow to send initial funds for a given user for the first time only by triggering the generic event 'exo.wallet.addressAssociation.new' which was triggered only when the wallet is initialized with a Browser Wallet.