### PR TITLE
feat: Exclude bcprov-jdk15on from wallet packaging - EXO-59676 - Meeds-io/MIPs#69

### DIFF
--- a/wallet-packaging/src/main/assemblies/assembly.xml
+++ b/wallet-packaging/src/main/assemblies/assembly.xml
@@ -40,6 +40,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <excludes>
+        <exclude>org.bouncycastle:bcprov-jdk15on:jar</exclude>
+      </excludes>
       <scope>compile</scope>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>


### PR DESCRIPTION
Prior to this change, bcprov-jdk15on jar is added in wallet packaging as it's coming as a compiled dependency in org.web3j.utils. 

With new feature about the new Argon2IdPasswordEncoder, this dependency is needed at gatein portal level. So this PR exclude this jar from compiled scope, so that, if someone uninstall wallet addon, the bcprov-jdk15on is not removed.
