### PR TITLE
fix: Fix wallet association for same address - MEED-2318

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/AddressAlreadyInUseException.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/AddressAlreadyInUseException.java
@@ -1,25 +1,24 @@
-/*
+/**
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
- * contact@meeds.io
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-const { merge } = require('webpack-merge');
-const webpackProductionConfig = require('./webpack.prod.js');
+package org.exoplatform.wallet.model;
 
-module.exports = merge(webpackProductionConfig, {
-  mode: 'development',
-  output: {
-    path: '/exo-server/webapps/wallet',
-  }
-});
+public class AddressAlreadyInUseException extends RuntimeException {
+
+  private static final long serialVersionUID = -6892231101205805806L;
+
+}

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -45,7 +45,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependency>
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
+      <artifactId>social-component-notification</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -57,7 +57,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
+      <artifactId>social-component-notification</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateBuilder.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/notification/RewardSuccessTemplateBuilder.java
@@ -38,6 +38,7 @@ import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.exoplatform.wallet.model.reward.RewardSettings;
 import org.exoplatform.wallet.reward.service.RewardSettingsService;
 import org.exoplatform.webui.utils.TimeConvertUtils;
@@ -89,6 +90,7 @@ public class RewardSuccessTemplateBuilder extends AbstractTemplateBuilder {
       templateContext.put("READ", Boolean.parseBoolean(notificationRead) ? "read" : "unread");
 
       setLastModifiedDate(notification, language, templateContext);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
 
       String body = TemplateUtils.processGroovy(templateContext);
       if (templateContext.getException() != null) {

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -40,7 +40,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependency>
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
+      <artifactId>social-component-notification</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -92,7 +92,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
+      <artifactId>social-component-notification</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumWalletTokenAdminService.java
@@ -426,6 +426,7 @@ public class EthereumWalletTokenAdminService implements WalletTokenAdminService,
           }
           transactionDetail.setPending(false);
           transactionDetail.setDropped(true);
+          transactionDetail.setNonce(0);
           transactionService.saveTransactionDetail(transactionDetail, true);
         } catch (Exception e) {
           LOG.warn("Can't boost transaction {} with the new one {}",

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
@@ -45,4 +45,11 @@ public class WalletAccountDAO extends GenericDAOJPAImpl<WalletEntity, Long> {
     return resultList == null || resultList.isEmpty() ? null : resultList.get(0);
   }
 
+  public List<WalletEntity> findListByAddress(String address) {
+    TypedQuery<WalletEntity> query = getEntityManager().createNamedQuery("Wallet.findByAddress",
+                                                                         WalletEntity.class);
+    query.setParameter("address", StringUtils.lowerCase(address));
+    return query.getResultList();
+  }
+
 }

--- a/wallet-services/src/main/java/org/exoplatform/wallet/notification/builder/RequestFundsTemplateBuilder.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/notification/builder/RequestFundsTemplateBuilder.java
@@ -40,6 +40,7 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.service.LinkProvider;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.exoplatform.wallet.model.WalletType;
 import org.exoplatform.webui.utils.TimeConvertUtils;
 
@@ -99,9 +100,10 @@ public class RequestFundsTemplateBuilder extends AbstractTemplateBuilder {
       templateContext.put("MESSAGE", message);
       templateContext.put("AVATAR", avatar != null ? avatar : LinkProvider.PROFILE_DEFAULT_AVATAR_URL);
       templateContext.put("NOTIFICATION_ID", notification.getId());
-      templateContext.put("READ", Boolean.valueOf(notificationRead) ? "read" : "unread");
+      templateContext.put("READ", Boolean.parseBoolean(notificationRead) ? "read" : "unread");
       templateContext.put("FUNDS_REQUEST_SENT", Boolean.valueOf(fundRequestSent));
       setLastModifiedDate(notification, language, templateContext);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
 
       String body = TemplateUtils.processGroovy(templateContext);
       // binding the exception throws by processing template

--- a/wallet-services/src/main/java/org/exoplatform/wallet/notification/builder/TemplateBuilder.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/notification/builder/TemplateBuilder.java
@@ -42,6 +42,7 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.service.LinkProvider;
+import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.exoplatform.wallet.model.WalletType;
 import org.exoplatform.webui.utils.TimeConvertUtils;
 
@@ -96,13 +97,14 @@ public class TemplateBuilder extends AbstractTemplateBuilder {
       templateContext.put("SYMBOL", symbol);
       templateContext.put("CONTRACT_ADDRESS", contractAddress == null ? "" : contractAddress);
       templateContext.put("NOTIFICATION_ID", notification.getId());
-      templateContext.put("READ", Boolean.valueOf(notificationRead) ? "read" : "unread");
+      templateContext.put("READ", Boolean.parseBoolean(notificationRead) ? "read" : "unread");
       templateContext.put("MESSAGE", message);
       templateContext.put("HASH", hash);
 
       String absoluteMyWalletLink = getWalletLink(receiverType, receiver);
       templateContext.put("BASE_URL", absoluteMyWalletLink);
       setLastUpdateDate(notification, language, templateContext);
+      SocialNotificationUtils.addFooterAndFirstName(notification.getTo(), templateContext);
 
       String body = TemplateUtils.processGroovy(templateContext);
       // binding the exception throws by processing template

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
@@ -319,6 +319,7 @@ public class WalletTransactionServiceImpl implements WalletTransactionService {
       transactions.forEach(replacedTransaction -> {
         replacedTransaction.setDropped(true);
         replacedTransaction.setPending(false);
+        replacedTransaction.setNonce(0);
         saveTransactionDetail(replacedTransaction, true);
         broadcastTransactionReplacedEvent(replacedTransaction, replacingTransaction);
       });

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/cached/CachedAccountStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/cached/CachedAccountStorage.java
@@ -79,7 +79,7 @@ public class CachedAccountStorage extends WalletStorage {
   }
 
   @Override
-  public Wallet saveWallet(Wallet wallet, boolean isNew) {
+  public Wallet saveWallet(Wallet wallet, boolean isNew) throws AddressAlreadyInUseException {
     String oldAddress = null;
     if (!isNew) {
       // Retrieve old wallet address

--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -477,3 +477,4 @@ exoplatform.wallet.message.followTransaction={0} link to follow your transaction
 
 wallet.mainCurrency=Matic
 wallet.mainCurrencySymbol=Matic
+wallet.addressAlreadyInUse=Address already in use by another wallet

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletTransactionServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletTransactionServiceTest.java
@@ -140,9 +140,11 @@ public class WalletTransactionServiceTest extends BaseWalletTest {
     storedTransactionDetail = walletTransactionService.getTransactionByHash(transactionDetail.getHash());
     assertFalse(storedTransactionDetail.isPending());
     assertFalse(storedTransactionDetail.isSucceeded());
+    assertEquals(0, storedTransactionDetail.getNonce());
     assertFalse(listenerInvoked.get());
 
     storedTransactionDetail.setPending(true);
+    storedTransactionDetail.setNonce(storedTransactionDetailReplacement.getNonce());
     walletTransactionService.saveTransactionDetail(storedTransactionDetail, true);
     errorReplacingTransaction = storedTransactionDetailReplacement.clone();
     errorReplacingTransaction.setContractAmount(5000);
@@ -150,9 +152,11 @@ public class WalletTransactionServiceTest extends BaseWalletTest {
     storedTransactionDetail = walletTransactionService.getTransactionByHash(transactionDetail.getHash());
     assertFalse(storedTransactionDetail.isPending());
     assertFalse(storedTransactionDetail.isSucceeded());
+    assertEquals(0, storedTransactionDetail.getNonce());
     assertFalse(listenerInvoked.get());
 
     storedTransactionDetail.setPending(true);
+    storedTransactionDetail.setNonce(storedTransactionDetailReplacement.getNonce());
     walletTransactionService.saveTransactionDetail(storedTransactionDetail, true);
     errorReplacingTransaction = storedTransactionDetailReplacement.clone();
     errorReplacingTransaction.setContractAddress("another address");
@@ -160,9 +164,11 @@ public class WalletTransactionServiceTest extends BaseWalletTest {
     storedTransactionDetail = walletTransactionService.getTransactionByHash(transactionDetail.getHash());
     assertFalse(storedTransactionDetail.isPending());
     assertFalse(storedTransactionDetail.isSucceeded());
+    assertEquals(0, storedTransactionDetail.getNonce());
     assertFalse(listenerInvoked.get());
 
     storedTransactionDetail.setPending(true);
+    storedTransactionDetail.setNonce(storedTransactionDetailReplacement.getNonce());
     walletTransactionService.saveTransactionDetail(storedTransactionDetail, true);
     walletTransactionService.cancelTransactionsWithSameNonce(storedTransactionDetailReplacement);
     assertTrue(listenerInvoked.get());

--- a/wallet-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -323,6 +323,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <module>eXoVueI18n</module>
     </depends>
     <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
       <module>jquery</module>
       <as>$</as>
     </depends>

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-app/spaceWallet.js
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-app/spaceWallet.js
@@ -17,20 +17,17 @@
 import SpaceWalletApp from './components/SpaceWalletApp.vue';
 import './initComponents.js';
 
-Vue.use(Vuetify);
 Vue.use(WalletCommon);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.Wallet-${lang}.json`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    new Vue({
+    Vue.createApp({
       render: (h) => h(SpaceWalletApp),
-      i18n,
-      vuetify,
-    }).$mount('#SpaceWalletApp');
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n
+    }, '#SpaceWalletApp', 'Space Wallet Application');
   });
 }

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-app/wallet.js
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-app/wallet.js
@@ -17,23 +17,20 @@
 import WalletApp from './components/WalletApp.vue';
 import './initComponents.js';
 
-Vue.use(Vuetify);
 Vue.use(WalletCommon);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.Wallet-${lang}.json`;
 
 export function init(generatedToken) {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    new Vue({
+    Vue.createApp({
       data: () => ({
         generatedToken,
       }),
       render: (h) => h(WalletApp),
-      i18n,
-      vuetify,
-    }).$mount('#WalletApp');
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n
+    }, '#WalletApp', 'User Wallet Application');
   });
 }

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/TransactionsList.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/TransactionsList.vue
@@ -15,7 +15,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-flex class="transactionsList">
+  <v-flex class="transactionsList text-start">
     <v-card class="card--flex-toolbar" flat>
       <div v-if="error && !loading" class="alert alert-error">
         <i class="uiIconError"></i>{{ error }}
@@ -361,7 +361,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <v-list-item-content>
                   {{ $t('exoplatform.wallet.label.transactionMessage') }}
                 </v-list-item-content>
-                <v-list-item-content class="align-end text-end paragraph text-truncate">
+                <v-list-item-content class="align-end text-start paragraph">
                   {{ item.message }}
                 </v-list-item-content>
               </v-list-item>

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/WalletWelcomeScreen.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/WalletWelcomeScreen.vue
@@ -106,8 +106,11 @@ export default {
           window.walletSettings.wallet.address = selectedAddress;
           window.walletSettings.wallet.provider = 'METAMASK';
         })
-        .catch(() => {
+        .catch(e => {
           this.savingMetamaskAddress = false;
+          if (String(e).includes('wallet.addressConflict')) {
+            this.$root.$emit('alert-message', this.$t('wallet.addressAlreadyInUse'), 'error');
+          }
         });
     },
     retrieveAddress() {

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/js/AddressRegistry.js
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/js/AddressRegistry.js
@@ -264,7 +264,11 @@ export function switchProvider(provider, address, rawMessage, signedMessage) {
     body: new URLSearchParams(formData).toString(),
   }).then(resp => {
     if (!resp || !resp.ok) {
-      throw new Error('Error saving new provider label');
+      if (resp.status === 409) {
+        throw new Error('wallet.addressConflict');
+      } else {
+        throw new Error('Error saving new provider label');
+      }
     }
   });
 }

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
@@ -174,9 +174,12 @@ export default {
           this.$root.$emit('wallet-settings-provider-changed', 'METAMASK');
           this.savingMetamaskAddress = false;
         })
-        .catch(() => {
+        .catch(e => {
           this.$root.$emit('wallet-settings-provider-changing', window.walletSettings.wallet.provider);
           this.savingMetamaskAddress = false;
+          if (String(e).includes('wallet.addressConflict')) {
+            this.$root.$emit('alert-message', this.$t('wallet.addressAlreadyInUse'), 'error');
+          }
         });
     },
     retrieveAddress() {

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/main.js
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/main.js
@@ -26,10 +26,7 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
 Vue.use(WalletCommon);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
 const lang = (eXo && eXo.env && eXo.env.portal && eXo.env.portal.language) || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.addon.Wallet-${lang}.json`;
@@ -45,7 +42,7 @@ export function init(generatedToken) {
       }),
       template: `<wallet-settings id="${appId}" />`,
       i18n,
-      vuetify,
+      vuetify: Vue.prototype.vuetifyOptions,
     }, `#${appId}`, 'Wallet Settings');
   });
 }


### PR DESCRIPTION
Prior to this change, two users wa able to use the same address for their Wallet. This change ensures to not have such a possible wallet association by adding a proper Alert message when doing so.

In addition, this change will fix Mail Notification Footer creation with missing 'COMPANY_LINK' variable.

In addition, this change will ensure to delete nonce of dropped transactions (New feature used to replace/resend transactions) to ensure to not have a not recognized nonce in blockchain.