### PR TITLE
fix: Fix Wallet Reward Computing Job - MEED-2455 - Meeds-io/meeds#1086

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/service/RewardReportService.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/service/RewardReportService.java
@@ -76,6 +76,11 @@ public interface RewardReportService {
   void saveRewardReport(RewardReport rewardReport);
 
   /**
+   * @return true if reward sending status storage is in progress, else return false
+   */
+  boolean isRewardSendingInProgress();
+
+  /**
    * @return a {@link List} of {@link RewardPeriod} that are in progress
    */
   List<RewardPeriod> getRewardPeriodsInProgress();

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
@@ -22,6 +22,9 @@ import java.util.List;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.services.log.ExoLogger;
@@ -90,7 +93,19 @@ public class RewardDAO extends GenericDAOJPAImpl<WalletRewardEntity, Long> {
   }
 
   private WalletRewardEntity getFirstItem(List<WalletRewardEntity> resultList) {
-    return resultList == null || resultList.isEmpty() ? null : resultList.get(0);
+    if (CollectionUtils.isEmpty(resultList)) {
+      return null;
+    } else {
+      return resultList.stream().filter(r -> StringUtils.isNotBlank(r.getTransactionHash())).sorted((r1, r2) -> {
+        if (r1.getTokensSent() > r2.getTokensSent()) {
+          return 1;
+        } else if (r2.getTokensSent() > r1.getTokensSent()) {
+          return -1;
+        } else {
+          return 0;
+        }
+      }).findFirst().orElse(resultList.get(0));
+    }
   }
 
 }

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
@@ -73,12 +73,16 @@ import org.exoplatform.wallet.reward.storage.WalletRewardReportStorage;
 import org.exoplatform.wallet.service.WalletAccountService;
 import org.exoplatform.wallet.service.WalletTokenAdminService;
 
+import lombok.Setter;
+
 /**
  * A service to manage reward reports
  */
 public class WalletRewardReportService implements RewardReportService {
 
-  private static final Log                LOG = ExoLogger.getLogger(WalletRewardReportService.class);
+  private static final Log                LOG            = ExoLogger.getLogger(WalletRewardReportService.class);
+
+  private static final String             EMPTY_SETTINGS = "Error computing rewards using empty settings";
 
   private final WalletAccountService      walletAccountService;
 
@@ -89,6 +93,9 @@ public class WalletRewardReportService implements RewardReportService {
   private final RewardTeamService         rewardTeamService;
 
   private final WalletRewardReportStorage rewardReportStorage;
+
+  @Setter
+  private boolean                         rewardSendingInProgress;
 
   public WalletRewardReportService(WalletAccountService walletAccountService,
                                    RewardSettingsService rewardSettingsService,
@@ -182,7 +189,17 @@ public class WalletRewardReportService implements RewardReportService {
         LOG.warn("Error while sending reward transaction for user '{}'", walletReward.getWallet().getName(), e);
       }
     }
-    rewardReportStorage.saveRewardReport(rewardReport);
+    this.rewardSendingInProgress = true;
+    try {
+      rewardReportStorage.saveRewardReport(rewardReport);
+    } finally {
+      this.rewardSendingInProgress = false;
+    }
+  }
+
+  @Override
+  public boolean isRewardSendingInProgress() {
+    return rewardSendingInProgress;
   }
 
   @Override
@@ -218,7 +235,7 @@ public class WalletRewardReportService implements RewardReportService {
   public RewardReport getRewardReport(LocalDate date) {
     RewardSettings rewardSettings = rewardSettingsService.getSettings();
     if (rewardSettings == null) {
-      throw new IllegalStateException("Error computing rewards using empty settings");
+      throw new IllegalStateException(EMPTY_SETTINGS);
     }
     if (rewardSettings.getPeriodType() == null) {
       throw new IllegalStateException("Error computing rewards using empty period type");
@@ -554,7 +571,7 @@ public class WalletRewardReportService implements RewardReportService {
         RewardTeamMember rewardTeamMember = new RewardTeamMember();
         rewardTeamMember.setIdentityId(identityId);
         return rewardTeamMember;
-      }).collect(Collectors.toList());
+      }).toList();
       noPoolRewardTeam.setMembers(noPoolRewardTeamList);
       noPoolRewardTeam.setId(0L);
       noPoolRewardTeam.setRewardType(RewardBudgetType.COMPUTED);

--- a/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/job/WalletRewardJobTest.java
+++ b/wallet-reward-services/src/test/java/org/exoplatform/wallet/reward/job/WalletRewardJobTest.java
@@ -48,11 +48,9 @@ import org.exoplatform.wallet.model.reward.WalletReward;
 import org.exoplatform.wallet.model.transaction.TransactionDetail;
 import org.exoplatform.wallet.reward.BaseWalletRewardTest;
 import org.exoplatform.wallet.reward.api.RewardPlugin;
-import org.exoplatform.wallet.reward.service.RewardTeamService;
 import org.exoplatform.wallet.reward.service.WalletRewardReportService;
 import org.exoplatform.wallet.reward.service.WalletRewardSettingsService;
 import org.exoplatform.wallet.reward.service.WalletRewardTeamService;
-import org.exoplatform.wallet.reward.storage.WalletRewardReportStorage;
 import org.exoplatform.wallet.service.WalletAccountService;
 import org.exoplatform.wallet.service.WalletTokenAdminService;
 import org.exoplatform.wallet.service.WalletTransactionService;
@@ -80,16 +78,10 @@ public class WalletRewardJobTest extends BaseWalletRewardTest {
 
   @Test
   public void testSendRewards() throws Exception {
-    WalletAccountService walletAccountService = getService(WalletAccountService.class);
     WalletRewardSettingsService rewardSettingsService = getService(WalletRewardSettingsService.class);
-    RewardTeamService rewardTeamService = getService(RewardTeamService.class);
     WalletTransactionService walletTransactionService = getService(WalletTransactionService.class);
-    WalletRewardReportStorage rewardReportStorage = getService(WalletRewardReportStorage.class);
 
-    WalletRewardReportService walletRewardService = new WalletRewardReportService(walletAccountService,
-                                                                                  rewardSettingsService,
-                                                                                  rewardTeamService,
-                                                                                  rewardReportStorage);
+    WalletRewardReportService walletRewardService = getService(WalletRewardReportService.class);
     WalletTokenAdminService tokenAdminService = Mockito.mock(WalletTokenAdminService.class);
     resetTokenAdminService(walletTransactionService, tokenAdminService, true, false);
 
@@ -189,6 +181,18 @@ public class WalletRewardJobTest extends BaseWalletRewardTest {
       adminWallet.setTokenBalance(3d);
       adminWallet.setEnabled(true);
 
+      rewardPeriodsInProgress = walletRewardService.getRewardPeriodsInProgress();
+      assertNotNull(rewardPeriodsInProgress);
+      assertEquals(1, rewardPeriodsInProgress.size());
+
+      walletRewardService.setRewardSendingInProgress(true);
+      rewardReportNotificationJob.execute(null);
+
+      rewardPeriodsInProgress = walletRewardService.getRewardPeriodsInProgress();
+      assertNotNull(rewardPeriodsInProgress);
+      assertEquals(1, rewardPeriodsInProgress.size());
+
+      walletRewardService.setRewardSendingInProgress(false);
       rewardReportNotificationJob.execute(null);
 
       rewardPeriodsInProgress = walletRewardService.getRewardPeriodsInProgress();


### PR DESCRIPTION
Prior to this fix, the Wallet Rewarding Job is sometimes executed at the same time then the rewards sending. This change ensure to not asynchronously compute rewards at the same time than executing a Reward Period Sending storage operation.