### PR TITLE
fix: Fix Displaye of Rewarded Transaction information when duplicated in database - MEED-2455 - Meeds-io/meeds#1086

### DIFF
--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
@@ -92,11 +92,11 @@ public class RewardDAO extends GenericDAOJPAImpl<WalletRewardEntity, Long> {
     return result == null ? 0 : result;
   }
 
-  private WalletRewardEntity getFirstItem(List<WalletRewardEntity> resultList) {
+  private static WalletRewardEntity getFirstItem(List<WalletRewardEntity> resultList) {
     if (CollectionUtils.isEmpty(resultList)) {
       return null;
     } else {
-      return resultList.stream().filter(r -> StringUtils.isNotBlank(r.getTransactionHash())).sorted((r1, r2) -> {
+      return resultList.stream().filter(r -> StringUtils.isNotBlank(r.getTransactionHash())).sorted((r2, r1) -> {
         if (r1.getTokensSent() > r2.getTokensSent()) {
           return 1;
         } else if (r2.getTokensSent() > r1.getTokensSent()) {

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
@@ -368,11 +368,19 @@ public class WalletRewardReportService implements RewardReportService {
 
     boolean completelyProceeded = rewardReport.isCompletelyProceeded();
     for (Wallet wallet : wallets) {
-      WalletReward walletReward = walletRewards.stream()
-                                               .filter(wr -> wallet != null && wr.getWallet() != null
-                                                   && wr.getIdentityId() == wallet.getTechnicalId())
-                                               .findFirst()
-                                               .orElse(null);
+      List<WalletReward> walletRewardList = walletRewards.stream()
+                                                         .filter(wr -> wallet != null && wr.getWallet() != null
+                                                             && wr.getIdentityId() == wallet.getTechnicalId())
+                                                         .toList();
+      WalletReward walletReward = walletRewardList.stream().filter(r -> r.getTransaction() != null).sorted((r2, r1) -> {
+        if (r1.getTokensSent() > r2.getTokensSent()) {
+          return 1;
+        } else if (r2.getTokensSent() > r1.getTokensSent()) {
+          return -1;
+        } else {
+          return 0;
+        }
+      }).findFirst().orElseGet(() -> walletRewardList.isEmpty() ? null : walletRewardList.get(0));
       if (walletReward == null) {
         walletReward = new WalletReward();
         walletRewards.add(walletReward);

--- a/wallet-webapps/pom.xml
+++ b/wallet-webapps/pom.xml
@@ -58,12 +58,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </artifactItems>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
           <execution>
             <id>platform-ui-src</id>
             <phase>generate-sources</phase>


### PR DESCRIPTION
Prior to this change, when the reward information is duplicated in database for a same period and identity, the first reward entity is retrieved which may not contain the Transaction information. This change ensures to display the reward information having the sent transaction instead of the first created one.