### PR TITLE
feat: Delete AppCenter Mandatory Flag - MEED-3034 - Meeds-io/meeds#1371

### DIFF
--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/app-center-configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/app-center-configuration.xml
@@ -62,9 +62,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <field name="active">
               <boolean>true</boolean>
             </field>
-            <field name="isMandatory">
-              <boolean>true</boolean>
-            </field>
             <field name="isMobile">
               <boolean>true</boolean>
             </field>


### PR DESCRIPTION
This change will delete mandatory flag from AppCenter application to let users choose it when needed instead of adding it systematically.