### PR TITLE
fix: Fix Accepting Funds Request Url - MEED-3060 - Meeds-io/meeds#1413

### DIFF
--- a/wallet-webapps/src/main/webapp/vue-app/notification-extension/components/FundsRequestNotification.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/notification-extension/components/FundsRequestNotification.vue
@@ -4,10 +4,9 @@
     :notification="notification"
     :avatar-url="userAvatarUrl"
     :message="message"
-    :actions-class="!content && 'd-none'"
     :url="userUrl">
-    <template v-if="content" #actions>
-      <div class="text-truncate">
+    <template #actions>
+      <div v-if="content" class="text-truncate">
         <v-icon size="14" class="me-1">far fa-comment</v-icon>
         {{ contentText }}
       </div>

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-app/components/wallet-app/SummaryButtons.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-app/components/wallet-app/SummaryButtons.vue
@@ -98,7 +98,10 @@ export default {
           }
           this.open();
           this.$nextTick(() => {
-            this.$refs.sendTokensModal.prepareSendForm(parameters.receiver, parameters.receiver_type, parameters.amount, parameters.id);
+            this.$refs.sendTokensModal.openSendTokenDrawer();
+            window.setTimeout(() => {
+              this.$refs.sendTokensModal.prepareSendForm(parameters.receiver, parameters.receiver_type, parameters.amount, parameters.id);
+            }, 50);
           });
         }
       }

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/SendTokensForm.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/SendTokensForm.vue
@@ -17,12 +17,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <template>
   <exo-drawer
     ref="sendTokensForm"
-    :right="!$vuetify.rtl">
+    :right="!$vuetify.rtl"
+    go-back-button>
     <template slot="title">
-      <div>
-        <i class="uiIcon uiArrowBackIcon" @click="close"></i> 
-        <span> {{ $t('exoplatform.wallet.button.sendfunds') }} </span>
-      </div>
+      {{ $t('exoplatform.wallet.button.sendfunds') }}
     </template>
     <template slot="content">
       <v-card
@@ -55,7 +53,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 recipient = $event.address;
                 $emit('receiver-selected', $event);
               " />
-            <p class="amountLabel mb-0 mt-2"> {{ $t('exoplatform.wallet.label.amount') }} </p>
+            <p class="amountLabel text-start mb-0 mt-2"> {{ $t('exoplatform.wallet.label.amount') }} </p>
             <v-text-field
               v-model.number="amount"
               ref="amount"
@@ -67,8 +65,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               validate-on-blur
               class="mt-n4"
               @input="$emit('amount-selected', amount)" />
-            <p v-if="!storedPassword && isInternalWallet" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.walletPassword') }}</p>
-            <p v-else-if="!isInternalWallet" class="amountLabel mb-0 mt-2">{{ $t('exoplatform.wallet.label.settings.internal') }}</p>
+            <p v-if="!storedPassword && isInternalWallet" class="amountLabel text-start mb-0 mt-2">{{ $t('exoplatform.wallet.label.walletPassword') }}</p>
+            <p v-else-if="!isInternalWallet" class="amountLabel text-start mb-0 mt-2">{{ $t('exoplatform.wallet.label.settings.internal') }}</p>
             <v-row class="pl-5" v-if="!isInternalWallet">
               <v-col
                 cols="12"


### PR DESCRIPTION
Prior to this change, when receiving a request funds Notification and accepting it, the Token Modal sending isn't displayed. This fixes the request funds popup display with prefilled value of receiver. In addition, this fixes the display of back button in drawer and labels alignment.
In addition, this will display accept and deny buttons even if there is no message sent with the request.