### PR TITLE
fix: Fix display of Space Wallet Creation for to non managers - MEED-…

### DIFF
--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/WalletSetup.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/components/WalletSetup.vue
@@ -50,24 +50,26 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <div v-if="displayWalletNotExistingYet" class="alert alert-info">
       <i class="uiIconInfo"></i> {{ $t('exoplatform.wallet.info.spaceWalletNotCreatedYet') }}
     </div>
-    <wallet-welcome-screen
-      v-if="displayWelcomeScreen && !displayWalletBrowserSetup && !isSpace && metamaskFeatureEnabled"
-      @create-internal-wallet="displayWalletBrowserSetup = true"
-      @configured="refresh()" />
-    <wallet-reward-browser-setup
-      v-if="displayWalletBrowserSetup || isSpace || !metamaskFeatureEnabled"
-      ref="walletBrowserSetup"
-      :is-space="isSpace"
-      :is-space-administrator="isSpaceAdministrator"
-      :wallet="wallet"
-      :refresh-index="refreshIndex"
-      :is-administration="isAdministration"
-      :loading="loading"
-      :initialization-state="initializationState"
-      @configured="refresh()"
-      @loading="$emit('loading')"
-      @end-loading="$emit('end-loading')"
-      @error="$emit('error', $event)" />
+    <template v-else>
+      <wallet-welcome-screen
+        v-if="displayWelcomeScreen && !displayWalletBrowserSetup && !isSpace && metamaskFeatureEnabled"
+        @create-internal-wallet="displayWalletBrowserSetup = true"
+        @configured="refresh()" />
+      <wallet-reward-browser-setup
+        v-if="displayWalletBrowserSetup || isSpace || !metamaskFeatureEnabled"
+        ref="walletBrowserSetup"
+        :is-space="isSpace"
+        :is-space-administrator="isSpaceAdministrator"
+        :wallet="wallet"
+        :refresh-index="refreshIndex"
+        :is-administration="isAdministration"
+        :loading="loading"
+        :initialization-state="initializationState"
+        @configured="refresh()"
+        @loading="$emit('loading')"
+        @end-loading="$emit('end-loading')"
+        @error="$emit('error', $event)" />
+    </template>
   </v-flex>
 </template>
 


### PR DESCRIPTION
…3059 - Meeds-io/meeds#1418 (#474)

Prior to this change, even if a space member can't create a space wallet, he still get a form displayed when accessing a space wallet that wasn't created by Space managers yet. This change will allow to display an information to space members visiting 'Wallet' menu entry of a space with a non-existing wallet.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
