### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -29,7 +29,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Wallet addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.08</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.12</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardReport.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardReport.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import lombok.Data;
 

--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardTransaction.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/reward/RewardTransaction.java
@@ -20,7 +20,7 @@ import static org.exoplatform.wallet.utils.WalletUtils.*;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.wallet.model.WalletType;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAccountREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAccountREST.java
@@ -33,7 +33,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAdminTransactionREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletAdminTransactionREST.java
@@ -24,7 +24,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.commons.utils.CommonsUtils;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletContractREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletContractREST.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletTransactionREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/rest/WalletTransactionREST.java
@@ -33,7 +33,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.commons.utils.CommonsUtils;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
@@ -30,7 +30,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardSettingsREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardSettingsREST.java
@@ -31,7 +31,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -43,7 +43,7 @@ import java.util.Set;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -631,7 +631,7 @@ public class WalletUtils {
     spaceUrl = CommonsUtils.getCurrentDomain() + spaceUrl;
     return new StringBuilder("<a href=\"").append(spaceUrl)
                                           .append("\" target=\"_blank\">")
-                                          .append(StringEscapeUtils.escapeHtml(space.getDisplayName()))
+                                          .append(StringEscapeUtils.escapeHtml4(space.getDisplayName()))
                                           .append("</a>")
                                           .toString();
   }

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-reward-services</artifactId>
   <name>eXo Add-on:: Wallet - Reward Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.81</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.82</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardDAO.java
@@ -19,8 +19,8 @@ package org.exoplatform.wallet.reward.dao;
 import java.util.Collections;
 import java.util.List;
 
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardPeriodDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardPeriodDAO.java
@@ -19,7 +19,7 @@ package org.exoplatform.wallet.reward.dao;
 import java.util.Collections;
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.model.reward.RewardPeriodType;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardPluginDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardPluginDAO.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.reward.dao;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardTeamDAO.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/dao/RewardTeamDAO.java
@@ -19,7 +19,7 @@ package org.exoplatform.wallet.reward.dao;
 import java.util.Collections;
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.reward.entity.RewardTeamEntity;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamEntity.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamMemberEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/RewardTeamMemberEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.reward.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.reward.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardPeriodEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardPeriodEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.reward.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardPluginEntity.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/entity/WalletRewardPluginEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.reward.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/listener/RewardSucceedAnalyticsListener.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/listener/RewardSucceedAnalyticsListener.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.analytics.model.StatisticData;
 import org.exoplatform.analytics.utils.AnalyticsUtils;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/service/WalletRewardReportService.java
@@ -47,7 +47,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/org/exoplatform/wallet/reward/storage/WalletRewardReportStorage.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>wallet-services</artifactId>
   <name>eXo Add-on:: Wallet - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.62</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountBackupDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountBackupDAO.java
@@ -19,8 +19,8 @@ package org.exoplatform.wallet.dao;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.entity.WalletBackupEntity;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import java.util.List;
 
 public class WalletAccountBackupDAO extends GenericDAOJPAImpl<WalletBackupEntity, Long> {

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletAccountDAO.java
@@ -18,9 +18,9 @@ package org.exoplatform.wallet.dao;
 
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.entity.WalletEntity;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletBlockchainStateDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletBlockchainStateDAO.java
@@ -18,8 +18,8 @@ package org.exoplatform.wallet.dao;
 
 import java.util.List;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.services.log.ExoLogger;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletPrivateKeyDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletPrivateKeyDAO.java
@@ -18,8 +18,8 @@ package org.exoplatform.wallet.dao;
 
 import java.util.List;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wallet.entity.WalletPrivateKeyEntity;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletTransactionDAO.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/dao/WalletTransactionDAO.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/AddressLabelEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/AddressLabelEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/TransactionEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/TransactionEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBackupEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBackupEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBlockchainStateEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletBlockchainStateEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletEntity.java
@@ -19,7 +19,7 @@ package org.exoplatform.wallet.entity;
 import java.io.Serializable;
 import java.util.Collection;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.exoplatform.wallet.model.WalletProvider;
 import org.exoplatform.wallet.model.WalletState;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletPrivateKeyEntity.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/entity/WalletPrivateKeyEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.entity;
 
 import java.io.Serializable;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.DynamicUpdate;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/listener/AutoTransactionListener.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/listener/AutoTransactionListener.java
@@ -1,6 +1,6 @@
 package org.exoplatform.wallet.listener;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.Asynchronous;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/listener/TransactionNotificationListener.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/listener/TransactionNotificationListener.java
@@ -18,7 +18,7 @@ package org.exoplatform.wallet.listener;
 
 import static org.exoplatform.wallet.utils.WalletUtils.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.PluginKey;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAccountServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletAccountServiceImpl.java
@@ -56,8 +56,8 @@ import java.util.Set;
 
 import jakarta.servlet.ServletContext;
 
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletContractServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletContractServiceImpl.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.picocontainer.Startable;
 

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
@@ -55,7 +55,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.api.notification.NotificationContext;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletTransactionServiceImpl.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;

--- a/wallet-services/src/main/java/org/exoplatform/wallet/storage/cached/CachedAccountStorage.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/storage/cached/CachedAccountStorage.java
@@ -16,7 +16,7 @@
  */
 package org.exoplatform.wallet.storage.cached;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.cache.future.FutureExoCache;
 import org.exoplatform.commons.cache.future.Loader;

--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/templates/notification/mail/WalletReceiverMailPlugin.gtmpl
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/templates/notification/mail/WalletReceiverMailPlugin.gtmpl
@@ -39,7 +39,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                                 <p style="margin:0 0 12px; color: #333333; font-family:HelveticaNeue,arial,tahoma,serif; font-size:13px; line-height: 20px;">
                                                   <%= ACCOUNT_TYPE.equals("space") ? _ctx.appRes("Notification.message.SpaceEtherReceiverNotificationPlugin", RECEIVER_URL, AMOUNT, SENDER, SYMBOL) : _ctx.appRes("Notification.message.EtherReceiverNotificationPlugin", AMOUNT, SENDER_URL, SYMBOL)%>
                                                 </p>
-                                                <% if(org.apache.commons.lang.StringUtils.isNotBlank(MESSAGE)) { %>
+                                                <% if(org.apache.commons.lang3.StringUtils.isNotBlank(MESSAGE)) { %>
                                                   <table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#ffffff" align="center" style="background-color: #ffffff; font-size: 12px;color:#333333;line-height: 18px; margin-bottom: 15px;">
                                                       <tbody>
                                                           <tr>

--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/templates/notification/mail/WalletSenderMailPlugin.gtmpl
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/templates/notification/mail/WalletSenderMailPlugin.gtmpl
@@ -50,7 +50,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                                 <p style="margin:0 0 12px; color: #333333; font-family:HelveticaNeue,arial,tahoma,serif; font-size:13px; line-height: 20px;">
                                                   <%= ACCOUNT_TYPE.equals("space") ? _ctx.appRes("Notification.message.SpaceEtherSenderNotificationPlugin", SENDER_URL, AMOUNT, RECEIVER_URL, SYMBOL) : _ctx.appRes("Notification.message.EtherSenderNotificationPlugin", AMOUNT, RECEIVER_URL, SYMBOL)%>
                                                 </p>
-                                                <% if(org.apache.commons.lang.StringUtils.isNotBlank(MESSAGE)) { %>
+                                                <% if(org.apache.commons.lang3.StringUtils.isNotBlank(MESSAGE)) { %>
                                                   <table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#ffffff" align="center" style="background-color: #ffffff; font-size: 12px;color:#333333;line-height: 18px; margin-bottom: 15px;">
                                                       <tbody>
                                                           <tr>


### PR DESCRIPTION
This change will upgrade from Commons Lang to Apache Lang 3, Hibernate 6.4 and will recompute the score of Tests coverage after excluding globally the POJOs from computation scopre computing. ( see https://github.com/Meeds-io/maven-parent-pom/pull/45 )