### PR TITLE
fix: Missing labels for events description - MEED-3068 - Meeds-io/meeds#1431

### DIFF
--- a/wallet-services/src/main/resources/locale/addon/Gamification_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Gamification_en.properties
@@ -1,1 +1,2 @@
 gamification.event.title.createWallet=Meeds - Wallet: Initialize the wallet
+gamification.event.description.createWallet=You Initialize your wallet


### PR DESCRIPTION
Add missing event description labels