### PR TITLE
feat: Allow to trigger Wallet Initialization gamification multiple times - MEED-3283 - Meeds-io/meeds#1628

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -187,8 +187,6 @@ public class WalletUtils {
 
   public static final String                          WALLET_MODIFIED_EVENT                    = "exo.wallet.modified";
 
-  public static final String                          WALLET_PROVIDER_MODIFIED_EVENT           = "exo.wallet.provider.modified";
-
   public static final String                          CONTRACT_MODIFIED_EVENT                  = "exo.wallet.contract.modified";
 
   public static final String                          TRANSACTION_MINED_AND_UPDATED_EVENT      =

--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/listener/WebSocketWalletListener.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/listener/WebSocketWalletListener.java
@@ -22,14 +22,19 @@ import org.exoplatform.services.listener.Listener;
 import org.exoplatform.wallet.model.Wallet;
 import org.exoplatform.wallet.service.WalletWebSocketService;
 
-public class WebSocketWalletListener extends Listener<Object, Wallet> {
+public class WebSocketWalletListener extends Listener<Object, Object> {
 
   private WalletWebSocketService webSocketService;
 
   @Override
-  public void onEvent(Event<Object, Wallet> event) throws Exception {
-    Wallet wallet = event.getData();
-    getWebSocketService().sendMessage(event.getEventName(), null, true, wallet.getAddress());
+  public void onEvent(Event<Object, Object> event) throws Exception {
+    Wallet wallet = event.getData() instanceof Wallet walletData ? walletData : null;
+    if (wallet == null) {
+      wallet = event.getSource() instanceof Wallet walletSource ? walletSource : null;
+    }
+    if (wallet != null) {
+      getWebSocketService().sendMessage(event.getEventName(), null, true, wallet.getAddress());
+    }
   }
 
   private WalletWebSocketService getWebSocketService() {

--- a/wallet-services/src/main/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListener.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListener.java
@@ -36,7 +36,7 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.wallet.model.Wallet;
 
 @Asynchronous
-public class GamificationWalletInitializationListener extends Listener<Object, String> {
+public class GamificationWalletInitializationListener extends Listener<Object, Object> {
 
   private ListenerService listenerService;
 
@@ -45,8 +45,14 @@ public class GamificationWalletInitializationListener extends Listener<Object, S
   }
 
   @Override
-  public void onEvent(Event<Object, String> event) throws Exception {
-    Wallet wallet = (Wallet) event.getSource();
+  public void onEvent(Event<Object, Object> event) throws Exception {
+    Wallet wallet = event.getData() instanceof Wallet walletData ? walletData : null;
+    if (wallet == null) {
+      wallet = event.getSource() instanceof Wallet walletSource ? walletSource : null;
+      if (wallet == null) {
+        return;
+      }
+    }
     Map<String, String> gam = new HashMap<>();
     gam.put(GAMIFICATION_EVENT_ID, GAMIFICATION_CREATE_WALLET_EVENT);
     gam.put(GAMIFICATION_EARNER_ID, String.valueOf(wallet.getTechnicalId()));

--- a/wallet-services/src/test/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListenerTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/listener/GamificationWalletInitializationListenerTest.java
@@ -56,7 +56,7 @@ public class GamificationWalletInitializationListenerTest {
   private Wallet                wallet;
 
   @Mock
-  private Event<Object, String> event;
+  private Event<Object, Object> event;
 
   @Test
   public void testInitializeWallet() throws Exception {

--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/gamification-configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/gamification-configuration.xml
@@ -30,6 +30,11 @@
       <set-method>addListener</set-method>
       <type>org.exoplatform.wallet.listener.GamificationWalletInitializationListener</type>
     </component-plugin>
+    <component-plugin>
+      <name>exo.wallet.addressAssociation.modification</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.wallet.listener.GamificationWalletInitializationListener</type>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
Prior to this change, when creating the 'Wallet Initialization' gamification action after having initialized the wallet, the gamification action isn't triggered. This change will trigger the action each time the user chooses an associated wallet to its account.