### PR TITLE
fix: Fix Wallet Notification Technical Labels - MEED-3283 - Meeds-io/meeds#1593

### DIFF
--- a/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/bundle-configuration.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/conf/wallet/bundle-configuration.xml
@@ -19,32 +19,27 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
-    <external-component-plugins>
-        <target-component>org.exoplatform.services.resources.ResourceBundleService</target-component>
-        <component-plugin>
-        <name>Wallet Portlet Resource Bundle</name>
-        <set-method>addResourceBundle</set-method>
-        <type>org.exoplatform.services.resources.impl.BaseResourceBundlePlugin</type>
-        <init-params>
-          <values-param>
-            <name>classpath.resources</name>
-            <value>locale.addon.Wallet</value>
-            <value>locale.notification.WalletNotification</value>
-          </values-param>
-            <values-param>
-                <name>portal.resource.names</name>
-                <value>locale.addon.Wallet</value>
-                <value>locale.notification.WalletNotification</value>
-                <value>locale.portlet.Portlets</value>
-            </values-param>
-            <values-param>
-                <name>init.resources</name>
-                <value>locale.addon.Wallet</value>
-                <value>locale.notification.WalletNotification</value>
-                <value>locale.portlet.Portlets</value>
-            </values-param>
-        </init-params>
-        </component-plugin>
-    </external-component-plugins>
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.resources.ResourceBundleService</target-component>
+    <component-plugin>
+      <name>Wallet Portlet Resource Bundle</name>
+      <set-method>addResourceBundle</set-method>
+      <type>org.exoplatform.services.resources.impl.BaseResourceBundlePlugin</type>
+      <init-params>
+        <values-param>
+          <name>classpath.resources</name>
+          <value>locale.addon.Wallet</value>
+        </values-param>
+        <values-param>
+          <name>portal.resource.names</name>
+          <value>locale.addon.Wallet</value>
+        </values-param>
+        <values-param>
+          <name>init.resources</name>
+          <value>locale.addon.Wallet</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 
 </configuration>


### PR DESCRIPTION
Prior to this change, the Wallet Notifications were randomly sent with technical labels instead of translated labels. This change will delete the definition of Notification Resource Bundles as generic Resource Bundles to make it exclusively used in Mail Notifications.