### PR TITLE
fix: Mark Transaction as Failed when Timedout - MEED-3357 - Meeds-io/meeds#1646

### DIFF
--- a/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionService.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionService.java
@@ -433,6 +433,14 @@ public class EthereumBlockchainTransactionService implements BlockchainTransacti
         || transaction.getBlockNumber() == null;
   }
 
+  private boolean canCheckPendingTransactionValidity(TransactionDetail transactionDetail) {
+    boolean isPending = transactionDetail.isPending();
+    boolean maxSendingTentativesReached = isMaxSendingTentativesReached(transactionDetail);
+    boolean isTimedOut = isTransactionTimedOut(transactionDetail);
+
+    return isPending && (isTimedOut || maxSendingTentativesReached);
+  }
+
   private boolean canSendPendingTransactionToBlockchain(TransactionDetail transactionDetail) {
     boolean isPending = transactionDetail.isPending();
     boolean maxSendingTentativesReached = isMaxSendingTentativesReached(transactionDetail);
@@ -665,6 +673,9 @@ public class EthereumBlockchainTransactionService implements BlockchainTransacti
 
   private TransactionDetail sendTransactionToBlockchain(TransactionDetail transactionDetail) {
     if (!canSendPendingTransactionToBlockchain(transactionDetail)) {
+      if (canCheckPendingTransactionValidity(transactionDetail)) {
+        checkPendingTransactionValidity(transactionDetail);
+      }
       return null;
     }
 

--- a/wallet-services/src/test/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/blockchain/service/EthereumBlockchainTransactionServiceTest.java
@@ -19,11 +19,7 @@ package org.exoplatform.wallet.blockchain.service;
 import static org.exoplatform.wallet.utils.WalletUtils.LAST_BLOCK_NUMBER_KEY_NAME;
 import static org.exoplatform.wallet.utils.WalletUtils.TRANSACTION_EFFECTIVELY_SENT_CODE;
 import static org.exoplatform.wallet.utils.WalletUtils.TRANSACTION_SENT_TO_BLOCKCHAIN_EVENT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -468,14 +464,17 @@ public class EthereumBlockchainTransactionServiceTest extends BaseWalletTest {
     assertNotNull(sentTransactions);
     assertEquals(0, sentTransactions.size());
 
-    verify(transactionService, never()).saveTransactionDetail(any(), anyBoolean());
     verify(ethereumClientConnector, never()).sendTransactionToBlockchain(any());
+    verify(transactionService).saveTransactionDetail(argThat(t -> {
+      return !t.isPending() && !t.isSucceeded();
+    }), anyBoolean());
 
     transactionDetail.setTimestamp(System.currentTimeMillis());
+    transactionDetail.setPending(true);
 
     service.sendPendingTransactionsToBlockchain();
 
-    verify(ethereumClientConnector, times(1)).sendTransactionToBlockchain(any());
+    verify(ethereumClientConnector).sendTransactionToBlockchain(any());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Prior to this change, when a transaction is outdated and still pending, it's not marked as failed. This change will mark it as failed after being timeoud out or after being sent multiple times without being mined.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
