### PR TITLE
fix: When a transaction is boosted, the reference of this tx in reward dashboard is not updated - EXO-70361

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -1021,7 +1021,7 @@ public class WalletUtils {
     String oldHash = "";
     String newHash = "";
     try {
-      if (oldTransaction == null || newTransaction == null || oldTransaction.isPending() || newTransaction.isPending()) {
+      if (oldTransaction == null || newTransaction == null || oldTransaction.isPending() || !(newTransaction.isPending())) {
         return;
       }
       oldHash = oldTransaction.getHash();

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletTransactionServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletTransactionServiceTest.java
@@ -105,7 +105,7 @@ public class WalletTransactionServiceTest extends BaseWalletTest {
     TransactionDetail transactionDetailReplacement = storedTransactionDetail.clone();
     transactionDetailReplacement.setHash(generateTransactionHash());
     transactionDetailReplacement.setId(0);
-    transactionDetailReplacement.setPending(false);
+    transactionDetailReplacement.setPending(true);
     walletTransactionService.saveTransactionDetail(transactionDetailReplacement, true);
     TransactionDetail storedTransactionDetailReplacement = walletTransactionService.getTransactionByHash(transactionDetailReplacement.getHash());
 


### PR DESCRIPTION
Before this fix, when a tx replace another one, the broadcastTransactionReplacedEvent is correctly launch, but the first test of this function verify if the newTx is pending. If the new tx is pending, it do nothing.

As the new tx is always pending, this function never do something This commit change the test to do nothing when the new tx IS NOT pending.

Resolves meeds-io/meeds#1516

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
