### PR TITLE
fix: Suggester ko in wallet app - MEED-3295 - Meeds-io/meeds#1605

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/model/settings/GlobalSettings.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/model/settings/GlobalSettings.java
@@ -40,8 +40,6 @@ public class GlobalSettings implements Serializable, Cloneable {
 
   private String               contractAddress  = null;
 
-  private String               accessPermission = null;
-
   private boolean              enabled;
 
   @Exclude

--- a/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/utils/WalletUtils.java
@@ -130,8 +130,6 @@ public class WalletUtils {
 
   public static final String                          NETWORK_WS_URL                           = "networkWSURL";
 
-  public static final String                          ACCESS_PERMISSION                        = "accessPermission";
-
   public static final String                          TOKEN_ADDRESS                            = "tokenAddress";
 
   public static final String                          DEFAULT_INITIAL_USER_FUND                = "defaultInitialFunds";
@@ -554,16 +552,6 @@ public class WalletUtils {
 
   public static final boolean isUserRewardingAdmin(String username) {
     return isUserMemberOfGroupOrUser(username, REWARDINGS_GROUP);
-  }
-
-  public static final boolean isUserMemberOfSpaceOrGroupOrUser(String username, String accessPermission) {
-    boolean isMember = true;
-    if (StringUtils.isNotBlank(accessPermission)) {
-      Space space = getSpace(accessPermission);
-      isMember = (space != null && getSpaceService().isMember(space, username))
-          || isUserMemberOfGroupOrUser(username, accessPermission);
-    }
-    return isMember;
   }
 
   public static final boolean isUserMemberOfGroupOrUser(String username, String permissionExpression) {

--- a/wallet-services/src/main/java/org/exoplatform/wallet/plugin/WalletFeaturePlugin.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/plugin/WalletFeaturePlugin.java
@@ -59,11 +59,7 @@ public class WalletFeaturePlugin extends FeaturePlugin {
     if (settings == null) {
       return false;
     }
-    String accessPermission = settings.getAccessPermission();
-    if (StringUtils.isBlank(accessPermission)) {
-      return true;
-    }
-    boolean walletEnabled = WalletUtils.isUserMemberOfSpaceOrGroupOrUser(username, accessPermission);
+    boolean walletEnabled = true;
     for (StateKey stateKey : stateKeys) {
       ConversationState state = getConversationRegistry().getState(stateKey);
       state.setAttribute("wallet.enabled", walletEnabled);

--- a/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
+++ b/wallet-services/src/main/java/org/exoplatform/wallet/service/WalletServiceImpl.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.wallet.service;
 
-import static org.exoplatform.wallet.utils.WalletUtils.ACCESS_PERMISSION;
 import static org.exoplatform.wallet.utils.WalletUtils.DEFAULT_INITIAL_USER_FUND;
 import static org.exoplatform.wallet.utils.WalletUtils.DEFAULT_MIN_GAS_PRICE;
 import static org.exoplatform.wallet.utils.WalletUtils.ETHER_TO_WEI_DECIMALS;
@@ -46,7 +45,6 @@ import static org.exoplatform.wallet.utils.WalletUtils.convertFromDecimals;
 import static org.exoplatform.wallet.utils.WalletUtils.fromJsonString;
 import static org.exoplatform.wallet.utils.WalletUtils.hideWalletOwnerPrivateInformation;
 import static org.exoplatform.wallet.utils.WalletUtils.isUserMemberOfGroupOrUser;
-import static org.exoplatform.wallet.utils.WalletUtils.isUserMemberOfSpaceOrGroupOrUser;
 import static org.exoplatform.wallet.utils.WalletUtils.isUserSpaceMember;
 import static org.exoplatform.wallet.utils.WalletUtils.toJsonString;
 
@@ -189,11 +187,6 @@ public class WalletServiceImpl implements WalletService, Startable {
     }
     network.setMaxGasPrice(maxGasPrice);
 
-    if (params.containsKey(ACCESS_PERMISSION)) {
-      String defaultAccessPermission = params.getValueParam(ACCESS_PERMISSION).getValue();
-      this.configuredGlobalSettings.setAccessPermission(defaultAccessPermission);
-    }
-
     if (params.containsKey(TOKEN_ADDRESS)) {
       String contractAddress = params.getValueParam(TOKEN_ADDRESS).getValue();
       this.configuredGlobalSettings.setContractAddress(contractAddress);
@@ -272,16 +265,7 @@ public class WalletServiceImpl implements WalletService, Startable {
 
     UserSettings userSettings = new UserSettings(globalSettings);
     userSettings.setEnabled(isEnabled());
-
-    String accessPermission = globalSettings.getAccessPermission();
-    boolean walletEnabled = isUserMemberOfSpaceOrGroupOrUser(currentUser, accessPermission);
-    userSettings.setWalletEnabled(walletEnabled);
-    if (!walletEnabled) {
-      LOG.debug("Wallet is disabled for user {} because he's not member of permission expression {}",
-                currentUser,
-                accessPermission);
-      return userSettings;
-    }
+    userSettings.setWalletEnabled(true);
 
     Wallet wallet = null;
     if (StringUtils.isNotBlank(spaceId)) {

--- a/wallet-services/src/main/resources/conf/portal/wallet-configuration.xml
+++ b/wallet-services/src/main/resources/conf/portal/wallet-configuration.xml
@@ -174,11 +174,6 @@
         <description>Default used gas for transactions</description>
         <value>${exo.wallet.transaction.gas.fastPrice:80000000000}</value>
       </value-param>
-      <value-param>
-        <name>accessPermission</name>
-        <description>Default access permission for wallet extension</description>
-        <value>${exo.wallet.accessPermission:}</value>
-      </value-param>
     </init-params>
   </component>
 

--- a/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletServiceTest.java
+++ b/wallet-services/src/test/java/org/exoplatform/wallet/service/WalletServiceTest.java
@@ -73,7 +73,6 @@ public class WalletServiceTest extends BaseWalletTest {
 
     GlobalSettings settings = walletService.getSettings();
     assertNotNull("Default settings shouldn't be null", settings);
-    assertTrue("Default permission should be null", StringUtils.isBlank(settings.getAccessPermission()));
     assertNotNull("Contract ABI should have been computed after container startup", settings.getContractAbi());
     assertNotNull("Contract BIN should have been computed after container startup", settings.getContractBin());
     assertNotNull("Default contract address shouldn't be null", settings.getContractAddress());
@@ -167,7 +166,6 @@ public class WalletServiceTest extends BaseWalletTest {
     assertNotNull("User settings shouldn't be null", userSettings);
     assertNotNull("Contract address shouldn't be null", userSettings.getContractAddress());
     assertNotNull("Contract bin shouldn't be null", userSettings.getContractBin());
-    assertNotNull("Access permission shouldn't be null", userSettings.getAccessPermission());
 
     NetworkSettings networkSettings = userSettings.getNetwork();
     assertNotNull("Default blockchain network settings shouldn't be null", networkSettings);
@@ -188,7 +186,6 @@ public class WalletServiceTest extends BaseWalletTest {
     assertNotNull("Contract address shouldn't be null", userSettings.getContractAddress());
     assertNotNull("Contract bin shouldn't be null", userSettings.getContractBin());
     assertNull("Initial funds should be null when user doesn't belong to rewarding group", userSettings.getInitialFunds());
-    assertNotNull("Access permission shouldn't be null", userSettings.getAccessPermission());
 
     // Add user to admin group
     org.exoplatform.services.security.Identity identity = buildUserIdentityAsAdmin(currentUser);
@@ -213,7 +210,6 @@ public class WalletServiceTest extends BaseWalletTest {
     assertNotNull("Global settings shouldn't be null", globalSettings);
     assertNotNull("Contract address shouldn't be null", globalSettings.getContractAddress());
     assertNotNull("Contract bin shouldn't be null", globalSettings.getContractBin());
-    assertNotNull("Access permission shouldn't be null", globalSettings.getAccessPermission());
   }
 
   /**

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/js/AddressRegistry.js
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/js/AddressRegistry.js
@@ -155,8 +155,7 @@ export function searchUsers(filter, includeCurrentUserInResults) {
   const params = $.param({
     nameToSearch: filter,
     typeOfRelation: 'mention_activity_stream',
-    currentUser: includeCurrentUserInResults ? '' : eXo.env.portal.userName,
-    spaceURL: isOnlySpaceMembers() ? getAccessPermission() : null,
+    currentUser: includeCurrentUserInResults ? '' : eXo.env.portal.userName
   });
   return fetch(`/portal/rest/social/people/suggest.json?${params}`, {credentials: 'include'})
     .then((resp) => {
@@ -233,19 +232,8 @@ export function saveAddressLabel(labelDetails) {
 }
 
 /*
- * Determins whether the suggested users should belong to a specific space or
- * not
- */
-function isOnlySpaceMembers() {
-  return window.walletSettings.accessPermission && window.walletSettings.accessPermission.length;
-}
-
-/*
  * Determins the specific space from where the users could be suggested
  */
-function getAccessPermission() {
-  return window.walletSettings.accessPermission;
-}
 
 
 export function switchProvider(provider, address, rawMessage, signedMessage) {


### PR DESCRIPTION
Prior to this change, the wallet suggester did not work because the spaceURL parameter was initialized with '/platform/user', meaning that only 'platform/user' groups were allowed to access the wallet. This change removes the spaceURL parameter to allow access to the wallet for all members.