### PR TITLE
feat: Disable realization status update from stream once reward sent - MEED-3437 - Meeds-io/MIPs#122

### DIFF
--- a/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
+++ b/wallet-api/src/main/java/org/exoplatform/wallet/reward/rest/RewardReportREST.java
@@ -258,7 +258,12 @@ public class RewardReportREST implements ResourceContainer {
     if (offset < 0) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Offset must be 0 or positive").build();
     }
-    List<RewardPeriod> rewardPeriods = rewardReportService.findRewardPeriodsBetween(from, to, offset, limit);
+    List<RewardPeriod> rewardPeriods;
+    if (from >= 0 && to > 0) {
+      rewardPeriods = rewardReportService.findRewardPeriodsBetween(from, to, offset, limit);
+    } else {
+      rewardPeriods = rewardReportService.findRewardReportPeriods(offset, limit);
+    }
     return Response.ok(rewardPeriods).build();
   }
 

--- a/wallet-webapps/src/main/webapp/vue-app/achievementsExtensions/extensions.js
+++ b/wallet-webapps/src/main/webapp/vue-app/achievementsExtensions/extensions.js
@@ -23,9 +23,15 @@ export function init() {
     type: 'wallet',
     rewardPeriods: [],
     init(from, to) {
-      getRewardReportPeriods(from, to, 0, -1).then(period => {
-        this.rewardPeriods = period;
-      });
+      if (from && to) {
+        getRewardReportPeriods(from, to, 0, -1).then(periods => {
+          this.rewardPeriods = periods;
+        });
+      } else {
+        getRewardReportPeriods(null, null, 0, -1).then(periods => {
+          this.rewardPeriods = periods;
+        });
+      }
     },
     canUpdateStatus(createdDate) {
       return this.rewardPeriods.filter(rewardPeriod => this.isInPeriod(rewardPeriod, createdDate)).length === 0;

--- a/wallet-webapps/src/main/webapp/vue-app/achievementsExtensions/js/service.js
+++ b/wallet-webapps/src/main/webapp/vue-app/achievementsExtensions/js/service.js
@@ -17,7 +17,7 @@
  *
  */
 export function getRewardReportPeriods(from, to, offset, limit) {
-  return fetch(`/portal/rest/wallet/api/reward/periods?from=${from}&to=${to}&offset=${offset || 0}&limit=${limit|| 10}`, {
+  return fetch(`/portal/rest/wallet/api/reward/periods?from=${from || 0}&to=${to || 0}&offset=${offset || 0}&limit=${limit|| 10}`, {
     method: 'GET',
     credentials: 'include',
     headers: {


### PR DESCRIPTION
This PR will ensure disabling the update achievement status from the stream once the reward is sent.