### PR TITLE
TASK-71389: avoid two many builds error with crowdin project

### DIFF
--- a/.github/workflows/download-crowdin.yml
+++ b/.github/workflows/download-crowdin.yml
@@ -2,7 +2,7 @@ name: Crowdin  download Action
 
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "35 2 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The changes aims to avoid the following error with crowdin project: Error from server: <Code: 429, Message: Too Many Project Builds>