### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/wallet-webapps/src/main/webapp/WEB-INF/web.xml
+++ b/wallet-webapps/src/main/webapp/WEB-INF/web.xml
@@ -38,7 +38,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)