### PR TITLE
fix: Delete Jcabi Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/wallet-api/pom.xml
+++ b/wallet-api/pom.xml
@@ -68,10 +68,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </swaggerConfig>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/wallet-packaging/src/main/assemblies/assembly.xml
+++ b/wallet-packaging/src/main/assemblies/assembly.xml
@@ -40,6 +40,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <excludes>
+        <exclude>io.meeds.social:*</exclude>
+        <exclude>org.aspectj:*</exclude>
+      </excludes>
       <scope>compile</scope>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>

--- a/wallet-reward-services/pom.xml
+++ b/wallet-reward-services/pom.xml
@@ -77,10 +77,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <finalName>wallet-reward-services</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/wallet-services/pom.xml
+++ b/wallet-services/pom.xml
@@ -107,10 +107,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <finalName>wallet-services</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -153,16 +149,24 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>io.meeds.portal</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+            <aspectLibrary>
+              <groupId>io.meeds.social</groupId>
+              <artifactId>social-component-api</artifactId>
+            </aspectLibrary>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>wallet-api</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This change will delete JCabi Plugin usage in favor of AspectJ Plugin for AspectJ Annotation processing.