### PR TITLE
feat: Fix display of threshold field in budget configuration drawer -MEED-7626 - Meeds-io/MIPs#154

### DIFF
--- a/wallet-webapps/src/main/webapp/vue-app/wallet-reward/components/reward/BudgetConfigurationDrawer.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-reward/components/reward/BudgetConfigurationDrawer.vue
@@ -70,7 +70,6 @@
       </v-card-title>
       <div class="d-flex align-center px-4">
         <number-input
-          v-if="settingsToSave.threshold"
           v-model="settingsToSave.threshold"
           :step="1"
           :max="1000"


### PR DESCRIPTION
This PR will fix the display of threshold field when equal to 0.