### PR TITLE
feat: Review Portlet Instances Default Permissions - MEED-7668 - Meeds-io/meeds#2528

### DIFF
--- a/wallet-services/src/main/resources/portlet-instances.json
+++ b/wallet-services/src/main/resources/portlet-instances.json
@@ -48,7 +48,8 @@
         
       ],
       "permissions":[
-        "*:/platform/users"
+        "*:/platform/administrators",
+        "*:/platform/web-contributors"
       ],
       "system":true
     }


### PR DESCRIPTION
This change will hide `Rewards` portlet instance for Space Managers when editing their layout to be visible for administrators and content managers only.