### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
@@ -26,6 +26,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <changeSet author="reward" id="1.0.0-1" runOnChange="false">
     <validCheckSum>7:b6e791d36a486b4501fde54aed6a4a8d</validCheckSum>
     <validCheckSum>7:ff477a093e9169fc1a89e113f14b8def</validCheckSum>
+    <validCheckSum>9:676c1fb6585d378abebdb2f820eb7f13</validCheckSum>
+    <validCheckSum>9:61baf10e7f52c9257b020cc9327fd51d</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <not>
         <tableExists tableName="ADDONS_WALLET_GAM_TEAM"/>
@@ -35,10 +37,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="TEAM_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_GAM_TEAM"/>
       </column>
-      <column name="TEAM_NAME" type="NVARCHAR(200)">
+      <column name="TEAM_NAME" type="VARCHAR(200)">
         <constraints nullable="false" unique="true" uniqueConstraintName="UK_WALLET_GAM_TEAM_NAME"/>
       </column>
-      <column name="TEAM_DESCRIPTION" type="NVARCHAR(2000)"/>
+      <column name="TEAM_DESCRIPTION" type="VARCHAR(2000)"/>
       <column name="TEAM_REWARD_TYPE" type="INT"/>
       <column name="TEAM_BUDGET" type="DOUBLE"/>
       <column name="TEAM_MEMBER_REWARD" type="DOUBLE"/>
@@ -47,13 +49,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="TEAM_DISABLED" type="BOOLEAN" defaultValueBoolean="false"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="reward" id="1.0.0-2" runOnChange="false" onValidationFail="MARK_RAN" failOnError="false">
     <validCheckSum>7:4c22877ac3021d85be104b086fff5ece</validCheckSum>
     <validCheckSum>7:64aeffaa9b8d94fbe10663101e431b30</validCheckSum>
+    <validCheckSum>9:d16a228cb65e236bd920b36cebf5f774</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <not>
         <tableExists tableName="ADDONS_WALLET_GAM_TEAM_MEMBER"/>
@@ -71,7 +74,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -87,6 +90,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="reward" id="1.0.0-6">
+    <validCheckSum>9:1a3a3681a57ebda58109e2517e054d22</validCheckSum>
     <createTable tableName="ADDONS_WALLET_REWARD_PERIOD">
       <column name="REWARD_PERIOD_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_REWARD_PERIOD_ID"/>
@@ -99,11 +103,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="STATUS" type="INT" defaultValueNumeric="0" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="reward" id="1.0.0-7">
+    <validCheckSum>9:e65f1822e3dec16668003775ad6ac5d6</validCheckSum>
     <createTable tableName="ADDONS_WALLET_REWARD">
       <column name="REWARD_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_REWARD_ID"/>
@@ -123,11 +128,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="TOKENS_SENT" type="DOUBLE" defaultValueNumeric="0" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="reward" id="1.0.0-8">
+    <validCheckSum>9:091538df9a026d00eecd6a201dc49756</validCheckSum>
     <createTable tableName="ADDONS_WALLET_REWARD_PLUGIN">
       <column name="REWARD_PLUGIN_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_REWARD_PLUGIN_ID"/>
@@ -141,7 +147,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="AMOUNT" type="DOUBLE" defaultValueNumeric="0" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -185,4 +191,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </addColumn>
   </changeSet>
 
+  <changeSet author="reward" id="1.0.0-15">
+    <sql dbms="mysql">
+      ALTER TABLE ADDONS_WALLET_GAM_TEAM CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_GAM_TEAM_MEMBER CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_REWARD_PERIOD CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_REWARD CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_REWARD_PLUGIN CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/wallet-services/src/main/resources/db/changelog/wallet-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-services/src/main/resources/db/changelog/wallet-rdbms.db.changelog-1.0.0.xml
@@ -24,6 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <property name="autoIncrement" value="false" dbms="oracle,postgresql"/>
 
   <changeSet author="wallet" id="1.3.0-1">
+    <validCheckSum>9:65b7b289fe5ce39c87dbcc00daa99f7d</validCheckSum>
     <createTable tableName="ADDONS_WALLET_ACCOUNT">
       <column name="IDENTITY_ID" type="BIGINT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_IDENTITY_ID"/>
@@ -40,13 +41,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="ENABLED" type="BOOLEAN"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="wallet" id="1.3.0-2">
     <validCheckSum>7:1b92fcacd4904402b5fc850db10ea561</validCheckSum>
     <validCheckSum>7:f4f8b6ffb1575004cfcb4ac607382fa9</validCheckSum>
+    <validCheckSum>9:e38b6eab36e9fae4925574c37f623651</validCheckSum>
     <createTable tableName="ADDONS_WALLET_TRANSACTION">
       <column name="TRANSACTION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_TRANSACTION_ID"/>
@@ -74,7 +76,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="CREATED_DATE" type="BIGINT" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -108,6 +110,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="wallet" id="1.3.0-6">
+    <validCheckSum>9:5446a1e5b198106a5ba38ebfdeef39a2</validCheckSum>
     <createTable tableName="ADDONS_WALLET_LABEL">
       <column name="LABEL_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_LABEL_ID"/>
@@ -121,7 +124,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -130,6 +133,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="wallet" id="1.3.0-8">
+    <validCheckSum>9:f7ac6241876aa72fe66d6bd909b8036b</validCheckSum>
     <createTable tableName="ADDONS_WALLET_KEY">
       <column name="KEY_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_KEY_ID"/>
@@ -142,7 +146,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -169,6 +173,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="wallet" id="1.3.0-15">
+    <validCheckSum>9:22beb2437192333c6b9d1d21aa3b73d2</validCheckSum>
     <createTable tableName="ADDONS_WALLET_BLOCKCHAIN_STATE">
       <column name="BLOCKCHAIN_STATE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_WALLET_BLOCKCHAIN_STATE_ID"/>
@@ -188,7 +193,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="IS_INITIALIZED" type="BOOLEAN" defaultValueBoolean="false" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -280,6 +285,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </changeSet>
 
   <changeSet author="wallet" id="1.3.0-30">
+    <validCheckSum>9:75d2d43de293219b3c3eb0f7eef4a5d0</validCheckSum>
     <createTable tableName="ADDONS_WALLET_ACCOUNT_BACKUP">
       <column name="WALLET_BACKUP_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints primaryKey="true" nullable="false" primaryKeyName="PK_WALLET_ACCOUNT_BACKUP_ID" />
@@ -296,7 +302,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -305,5 +311,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <column name="DROPPED" type="BOOLEAN" defaultValueBoolean="false" />
     </addColumn>
   </changeSet>
-
+  <changeSet author="wallet" id="1.3.0-32">
+    <sql dbms="mysql">
+      ALTER TABLE ADDONS_WALLET_ACCOUNT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_TRANSACTION CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_LABEL CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_KEY CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_BLOCKCHAIN_STATE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE ADDONS_WALLET_ACCOUNT_BACKUP CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/wallet-webapps/package-lock.json
+++ b/wallet-webapps/package-lock.json
@@ -5876,9 +5876,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
