### PR TITLE
fix: Fix Missing info for rewards history - MEED-7698 - Meeds-io/MIPs#154

### DIFF
--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardDAO.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardDAO.java
@@ -52,8 +52,10 @@ public interface RewardDAO extends JpaRepository<WalletRewardEntity, Long> {
       """)
   Double countWalletRewardsPointsByPeriodIdAndStatus(@Param("periodId") long periodId,
                                                      @Param("isValid") boolean isValid);
-
-  List<WalletRewardEntity> findWalletRewardEntitiesByIdentityId(long identityId, Pageable pageable);
+ @Query("""
+          SELECT rw FROM Reward rw JOIN rw.period WHERE rw.identityId = :identityId ORDER BY rw.period.startTime DESC, rw.period.endTime ASC
+      """)
+  List<WalletRewardEntity> findWalletRewardEntitiesByIdentityId(@Param("identityId") long identityId, Pageable pageable);
 
   double countWalletRewardEntitiesByIdentityId(long identityId);
 


### PR DESCRIPTION
Prior to this change, when access the overview page and click on “Reward” to see all rewards, the Reward tab was empty.