### PR TITLE
fix: Do not suggest opening a transaction if no reward has been sent - MEED-7831 - Meeds-io/#154

### DIFF
--- a/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
+++ b/wallet-services/src/main/resources/locale/addon/Wallet_en.properties
@@ -576,7 +576,6 @@ wallet.administration.rewardDetails.label.seeHistory=See History
 wallet.administration.rewardDetails.label.latestRewardsSent=Latest Rewards Sent on:
 wallet.administration.rewardDetails.label.rewardsToSend={0} MEED for {1} points
 wallet.administration.rewardDetails.label.reward=Reward
-wallet.administration.rewardDetails.label.notSentYet=Not sent yet
 wallet.administration.rewardDetails.label.export=Export
 wallet.administration.rewardDetails.label.filter=Filter
 wallet.administration.rewardDetails.label.filterRewardList=Filter Rewards List

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-reward/components/reward/RewardDetailsItem.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-reward/components/reward/RewardDetailsItem.vue
@@ -133,31 +133,21 @@
           </v-btn>
         </template>
         <v-list class="pa-0">
-          <v-tooltip
-            bottom
-            :disabled="status">
-            <template #activator="{ on }">
-              <div v-on="on" class="d-inline-block">
-                <v-list-item
-                  :disabled="!status"
-                  :href="`${transactionEtherScanLink}${transactionHash}`"
-                  target="_blank"
-                  dense
-                  @mousedown="$event.preventDefault()">
-                  <v-list-item-icon class="me-2 my-auto">
-                    <v-icon
-                      :disabled="!status"
-                      size="14"
-                      class="icon-default-color">
-                      fas fa-external-link-alt
-                    </v-icon>
-                  </v-list-item-icon>
-                  <v-list-item-title class="d-flex">{{ $t('wallet.administration.rewardDetails.label.openTransaction') }}</v-list-item-title>
-                </v-list-item>
-              </div>
-            </template>
-            <span>{{ $t('wallet.administration.rewardDetails.label.notSentYet') }}</span>
-          </v-tooltip>
+          <v-list-item
+            v-if="status"
+            :href="`${transactionEtherScanLink}${transactionHash}`"
+            target="_blank"
+            dense
+            @mousedown="$event.preventDefault()">
+            <v-list-item-icon class="me-2 my-auto">
+              <v-icon
+                size="14"
+                class="icon-default-color">
+                fas fa-external-link-alt
+              </v-icon>
+            </v-list-item-icon>
+            <v-list-item-title class="d-flex">{{ $t('wallet.administration.rewardDetails.label.openTransaction') }}</v-list-item-title>
+          </v-list-item>
           <v-list-item
             dense
             @mousedown="$event.preventDefault()"


### PR DESCRIPTION
Do not suggest opening a transaction if no reward has been sent.