### PR TITLE
fix: Actions cancelled/deleted must not be rewarded - MEED-7841 - Meeds-io/MIPs#154

### DIFF
--- a/wallet-api/src/main/java/io/meeds/wallet/model/WalletReward.java
+++ b/wallet-api/src/main/java/io/meeds/wallet/model/WalletReward.java
@@ -32,6 +32,8 @@ import lombok.EqualsAndHashCode.Exclude;
 public class WalletReward implements Serializable {
   private static final long serialVersionUID = -4328398843364453949L;
 
+  private long              id;
+
   private Wallet            wallet;
 
   @Exclude

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardDAO.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardDAO.java
@@ -114,4 +114,10 @@ public interface RewardDAO extends JpaRepository<WalletRewardEntity, Long> {
       """)
   Integer findRankById(@Param("id") long id,
                        @Param("periodId") long periodId);
+
+  @Modifying
+  @Query("""
+      DELETE FROM Reward wr WHERE wr.period.id = :periodId
+      """)
+  void deleteRewardsByPeriodId(@Param("periodId") long periodId);
 }

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/listener/RewardReportUpdateListener.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/listener/RewardReportUpdateListener.java
@@ -21,8 +21,12 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import io.meeds.gamification.model.Announcement;
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.service.RealizationService;
 import io.meeds.wallet.model.RewardPeriod;
 import io.meeds.wallet.model.RewardSettings;
 import io.meeds.wallet.reward.service.RewardReportService;
@@ -41,6 +45,7 @@ import jakarta.annotation.PostConstruct;
 
 import static io.meeds.gamification.utils.Utils.*;
 import static io.meeds.wallet.reward.service.WalletRewardSettingsService.REWARD_SETTINGS_UPDATED;
+import static io.meeds.wallet.utils.RewardUtils.parseRFC3339ToZonedDateTime;
 import static io.meeds.wallet.utils.WalletUtils.MODIFY_ADDRESS_ASSOCIATED_EVENT;
 import static io.meeds.wallet.utils.WalletUtils.NEW_ADDRESS_ASSOCIATED_EVENT;
 
@@ -71,6 +76,9 @@ public class RewardReportUpdateListener extends Listener<Object, Map<String, Str
   @Autowired
   private ListenerService           listenerService;
 
+  @Autowired
+  private RealizationService        realizationService;
+
   @PostConstruct
   public void init() {
     EVENT_NAMES.forEach(name -> listenerService.addListener(name, this));
@@ -86,12 +94,31 @@ public class RewardReportUpdateListener extends Listener<Object, Map<String, Str
       updatedSettings = rewardPeriods.stream().collect(Collectors.toMap(RewardPeriod::getId, rewardPeriod -> true));
     } else {
       RewardSettings rewardSettings = rewardSettingsService.getSettings();
-      RewardPeriod rewardPeriod = rewardReportService.getRewardPeriod(rewardSettings.getPeriodType(), LocalDate.now());
+      RewardPeriod rewardPeriod;
+      RealizationDTO realization = getRealization(event.getSource());
+      if (realization != null) {
+        rewardPeriod =
+                     rewardReportService.getRewardPeriod(rewardSettings.getPeriodType(),
+                                                         Objects.requireNonNull(parseRFC3339ToZonedDateTime(realization.getCreatedDate(),
+                                                                                                            rewardSettings.zoneId()))
+                                                                .toLocalDate());
+      } else {
+        rewardPeriod = rewardReportService.getRewardPeriod(rewardSettings.getPeriodType(), LocalDate.now());
+      }
       if (rewardPeriod == null) {
         return;
       }
       updatedSettings.put(rewardPeriod.getId(), true);
     }
     rewardReportService.setRewardSettingChanged(updatedSettings);
+  }
+
+  private RealizationDTO getRealization(Object object) {
+    if (object instanceof RealizationDTO realization) {
+      return realization;
+    } else if (object instanceof Announcement announcement) {
+      return realizationService.getRealizationById(announcement.getId());
+    }
+    return null;
   }
 }

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/service/WalletRewardReportService.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/service/WalletRewardReportService.java
@@ -265,6 +265,10 @@ public class WalletRewardReportService implements RewardReportService {
     if (CollectionUtils.isNotEmpty(participants)) {
       Set<Wallet> wallets = walletAccountService.listWalletsByIdentityIds(participants);
       computeRewardDetails(rewardReport, wallets);
+    } else {
+      RewardPeriod period = getRewardPeriod(rewardPeriod.getRewardPeriodType(), date);
+      rewardReportStorage.deleteRewardsByPeriodId(period.getId());
+      rewardReport.setRewards(new HashSet<>());
     }
     return rewardReport;
   }
@@ -528,6 +532,7 @@ public class WalletRewardReportService implements RewardReportService {
     Map<Long, Double> earnedPoints = getEarnedPoints(identityIds, period.getStartDateInSeconds(), period.getEndDateInSeconds());
 
     computeReward(rewardSettings, earnedPoints, enabledRewards);
+    rewardReport.setRewards(enabledRewards);
   }
 
   private Map<Long, Double> getEarnedPoints(Set<Long> identityIds, long startDateInSeconds, long endDateInSeconds) {
@@ -620,6 +625,20 @@ public class WalletRewardReportService implements RewardReportService {
   private void addRewardsSwitchPointAmount(Set<WalletReward> enabledRewards,
                                            Set<Entry<Long, Double>> identitiesPointsEntries,
                                            double amountPerPoint) {
+
+    Set<Long> identityIds = identitiesPointsEntries.stream().map(Entry::getKey).collect(Collectors.toSet());
+
+    // Iterate over enabledRewards and delete rewards not in
+    // identitiesPointsEntries.
+    Iterator<WalletReward> iterator = enabledRewards.iterator();
+    while (iterator.hasNext()) {
+      WalletReward walletReward = iterator.next();
+      if (!identityIds.contains(walletReward.getIdentityId())) {
+        rewardReportStorage.deleteRewardById(walletReward.getId());
+        iterator.remove();
+      }
+    }
+
     for (Entry<Long, Double> identitiyPointsEntry : identitiesPointsEntries) {
       Long identityId = identitiyPointsEntry.getKey();
       Double points = identitiyPointsEntry.getValue();

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
@@ -47,6 +47,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public class WalletRewardReportStorage {
@@ -270,6 +271,16 @@ public class WalletRewardReportStorage {
     return countWalletRewardsPoints != null ? countWalletRewardsPoints : 0;
   }
 
+  @Transactional
+  public void deleteRewardById(long rewardId) {
+    rewardDAO.deleteById(rewardId);
+  }
+
+  @Transactional
+  public void deleteRewardsByPeriodId(long periodId) {
+    rewardDAO.deleteRewardsByPeriodId(periodId);
+  }
+
   private RewardPeriod toDTO(WalletRewardPeriodEntity period) {
     if (period == null) {
       return null;
@@ -287,6 +298,7 @@ public class WalletRewardReportStorage {
 
   private WalletReward toDTO(WalletRewardEntity rewardEntity, ZoneId zoneId) {
     WalletReward walletReward = new WalletReward();
+    walletReward.setId(rewardEntity.getId());
     walletReward.setAmount(rewardEntity.getTokensToSend());
     walletReward.setPoints(rewardEntity.getPoints() == null ? 0d : rewardEntity.getPoints());
     retrieveWallet(rewardEntity, walletReward);

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardReportUpdateListenerTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardReportUpdateListenerTest.java
@@ -19,9 +19,13 @@
 package io.meeds.wallet.reward.listener;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.service.RealizationService;
+import io.meeds.gamification.utils.Utils;
 import io.meeds.wallet.model.*;
 import io.meeds.wallet.reward.service.RewardSettingsService;
 import io.meeds.wallet.reward.service.WalletRewardReportService;
@@ -50,6 +54,9 @@ class RewardReportUpdateListenerTest {
   private ListenerService                    listenerService;
 
   @MockBean
+  private RealizationService                 realizationService;
+
+  @MockBean
   private Event<Object, Map<String, String>> event;
 
   @Autowired
@@ -65,10 +72,7 @@ class RewardReportUpdateListenerTest {
     when(rewardPeriod2.getId()).thenReturn(2L);
 
     // Given
-    List<RewardPeriod> rewardPeriodsNotSent = List.of(
-            rewardPeriod1,
-            rewardPeriod2
-    );
+    List<RewardPeriod> rewardPeriodsNotSent = List.of(rewardPeriod1, rewardPeriod2);
     when(rewardReportService.getRewardPeriodsNotSent()).thenReturn(rewardPeriodsNotSent);
 
     Map<Long, Boolean> initialSettings = new HashMap<>();
@@ -79,9 +83,9 @@ class RewardReportUpdateListenerTest {
 
     // Then
     Map<Long, Boolean> expectedUpdatedSettings = rewardPeriodsNotSent.stream()
-            .collect(Collectors.toMap(RewardPeriod::getId, rewardPeriod -> true));
+                                                                     .collect(Collectors.toMap(RewardPeriod::getId,
+                                                                                               rewardPeriod -> true));
     verify(rewardReportService, times(1)).setRewardSettingChanged(expectedUpdatedSettings);
-
 
     List<RewardPeriod> rewardPeriods = Arrays.asList(rewardPeriod1, rewardPeriod2);
     when(rewardReportService.getRewardPeriodsNotSent()).thenReturn(rewardPeriods);
@@ -117,6 +121,41 @@ class RewardReportUpdateListenerTest {
       // Then
       expectedUpdatedSettings = new HashMap<>();
       expectedUpdatedSettings.put(1L, true);
+      verify(rewardReportService, times(1)).setRewardSettingChanged(expectedUpdatedSettings);
+    }
+  }
+
+  @Test
+  void onRealizationUpdateEvent() {
+    when(event.getEventName()).thenReturn(REWARD_SETTINGS_UPDATED);
+
+    RewardPeriod rewardPeriod1 = mock(RewardPeriod.class);
+    RewardPeriod rewardPeriod2 = mock(RewardPeriod.class);
+    when(rewardPeriod1.getId()).thenReturn(1L);
+    when(rewardPeriod2.getId()).thenReturn(2L);
+
+    when(event.getEventName()).thenReturn("OTHER_EVENT");
+    RealizationDTO realizationDTO = new RealizationDTO();
+    realizationDTO.setId(1L);
+    realizationDTO.setCreatedDate(Utils.toRFC3339Date(new Date(System.currentTimeMillis())));
+    when(event.getSource()).thenReturn(realizationDTO);
+
+    RewardSettings rewardSettings = mock(RewardSettings.class);
+    when(rewardSettingsService.getSettings()).thenReturn(rewardSettings);
+    RewardPeriod rewardPeriod = mock(RewardPeriod.class);
+    when(rewardPeriod.getId()).thenReturn(2L);
+    when(rewardReportService.getRewardPeriod(any(RewardPeriodType.class), any(LocalDate.class))).thenReturn(rewardPeriod);
+    try (MockedStatic<RewardPeriod> mockedRewardPeriod = mockStatic(RewardPeriod.class)) {
+      mockedRewardPeriod.when(() -> RewardPeriod.getCurrentPeriod(rewardSettings)).thenReturn(rewardPeriod);
+      // Given
+      when(rewardSettingsService.getSettings()).thenReturn(rewardSettings);
+      when(rewardSettings.getPeriodType()).thenReturn(RewardPeriodType.MONTH);
+      when(rewardSettings.zoneId()).thenReturn(ZoneId.systemDefault());
+
+      // When
+      rewardReportUpdateListener.onEvent(event);
+      Map<Long, Boolean> expectedUpdatedSettings = new HashMap<>();
+      expectedUpdatedSettings.put(2L, true);
       verify(rewardReportService, times(1)).setRewardSettingChanged(expectedUpdatedSettings);
     }
   }

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/notification/RewardSuccessNotificationPluginTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/notification/RewardSuccessNotificationPluginTest.java
@@ -66,7 +66,7 @@ public class RewardSuccessNotificationPluginTest {
         transaction.setHash("hash");
         transaction.setContractAmount(2);
         transaction.setPending(true);
-        rewards.add(new WalletReward(null, transaction, 0, 0, 0, null, 1));
+        rewards.add(new WalletReward(1, null, transaction, 0, 0, 0, null, 1));
       }
       rewardReport.setRewards(rewards);
 

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/notification/RewardSuccessTemplateBuilderTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/notification/RewardSuccessTemplateBuilderTest.java
@@ -81,7 +81,7 @@ public class RewardSuccessTemplateBuilderTest extends BaseExoTestCase {
         transaction.setHash("hash");
         transaction.setContractAmount(2);
         transaction.setPending(true);
-        rewards.add(new WalletReward(null, transaction, 0, 0, 0, null, 1));
+        rewards.add(new WalletReward(1, null, transaction, 0, 0, 0, null, 1));
       }
       rewardReport.setRewards(rewards);
       ctx.append(REWARD_REPORT_NOTIFICATION_PARAM, rewardReport);

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/rest/TestRewardReportREST.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/rest/TestRewardReportREST.java
@@ -415,7 +415,7 @@ class TestRewardReportREST {
   }
 
   private WalletReward walletReward() {
-    return new WalletReward(new Wallet(), new TransactionDetail(), 1L, 100.0, 40.0, rewardPeriod(), 1);
+    return new WalletReward(1, new Wallet(), new TransactionDetail(), 1L, 100.0, 40.0, rewardPeriod(), 1);
   }
 
   @SneakyThrows

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/service/WalletRewardReportServiceTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/service/WalletRewardReportServiceTest.java
@@ -118,6 +118,15 @@ public class WalletRewardReportServiceTest { // NOSONAR
     assertNotNull(rewardReport);
     // Even if settings are null, the returned rewards shouldn't be empty
     assertEquals(participantsWallet.size(), rewardReport.getRewards().size());
+
+    when(realizationService.getParticipantsBetweenDates(any(Date.class), any(Date.class))).thenReturn(new ArrayList<>());
+    RewardPeriod rewardPeriod = new RewardPeriod();
+    rewardPeriod.setId(1);
+    when(rewardReportService.getRewardPeriod(rewardSettings.getPeriodType(), date)).thenReturn(rewardPeriod);
+
+    rewardReportService.computeRewards(date);
+
+    verify(rewardReportStorage, times(1)).deleteRewardsByPeriodId(1);
   }
 
   @Test
@@ -341,9 +350,9 @@ public class WalletRewardReportServiceTest { // NOSONAR
       Set<WalletReward> walletRewards = new HashSet<>();
       TransactionDetail transactionDetail = new TransactionDetail();
       transactionDetail.setSucceeded(true);
-      walletRewards.add(new WalletReward(wallet, transactionDetail, 1L, 100, 10, rewardPeriod, 3));
-      walletRewards.add(new WalletReward(wallet4, transactionDetail, 4L, 200, 50, rewardPeriod, 2));
-      walletRewards.add(new WalletReward(wallet5, transactionDetail, 5L, 300, 40, rewardPeriod, 1));
+      walletRewards.add(new WalletReward(1, wallet, transactionDetail, 1L, 100, 10, rewardPeriod, 3));
+      walletRewards.add(new WalletReward(2, wallet4, transactionDetail, 4L, 200, 50, rewardPeriod, 2));
+      walletRewards.add(new WalletReward(3, wallet5, transactionDetail, 5L, 300, 40, rewardPeriod, 1));
       rewardReport.setRewards(walletRewards);
       when(rewardReportStorage.getRewardReport(newSettings.getPeriodType(), date, newSettings.zoneId())).thenReturn(rewardReport);
 
@@ -454,6 +463,18 @@ public class WalletRewardReportServiceTest { // NOSONAR
     assertEquals(200, row1.getCell(2).getNumericCellValue());
     assertEquals("MEED 50", row1.getCell(3).getStringCellValue());
     assertEquals("success", row1.getCell(4).getStringCellValue());
+  }
+
+  @Test
+  void testCountWalletRewardsPointsByPeriodIdAndStatus() {
+    rewardReportService.countWalletRewardsPointsByPeriodIdAndStatus(1, true);
+    verify(rewardReportStorage, times(1)).countWalletRewardsPointsByPeriodIdAndStatus(1, true);
+  }
+
+  @Test
+  void testReplaceRewardTransactions() {
+    rewardReportService.replaceRewardTransactions("oldHash", "newHash");
+    verify(rewardReportStorage, times(1)).replaceRewardTransactions("oldHash", "newHash");
   }
 
   protected Wallet newWallet(long identityId) {

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
@@ -95,6 +95,9 @@ class WalletRewardReportStorageTest {
                                                                List.of(IDENTITY_ID),
                                                                WalletRewardStatus.ALL.name(),
                                                                PAGEABLE)).thenReturn(new PageImpl<>(List.of(rewardEntity)));
+      when(rewardDAO.findWalletRewardsByPeriodId(REWARD_PERIOD_ID,
+                                                 WalletRewardStatus.ESTIMATED.name(),
+                                                 PAGEABLE)).thenReturn(new PageImpl<>(List.of(rewardEntity)));
       return rewardEntity;
     });
     doAnswer(invocation -> {
@@ -151,6 +154,7 @@ class WalletRewardReportStorageTest {
     assertNotNull(walletRewardReportStorage.findRewardReportPeriods(PAGEABLE));
     assertNotNull(walletRewardReportStorage.findRewardPeriodsBetween(12125, 222125, PAGEABLE));
     assertNotNull(walletRewardReportStorage.getRewardPeriod(RewardPeriodType.WEEK, LocalDate.now(), ZoneId.systemDefault()));
+    assertNotNull(walletRewardReportStorage.findWalletRewardsByPeriodId(REWARD_PERIOD_ID, ZoneId.systemDefault(), WalletRewardStatus.ESTIMATED, PAGEABLE));
   }
 
   @Test
@@ -217,9 +221,9 @@ class WalletRewardReportStorageTest {
     Set<WalletReward> walletRewards = new HashSet<>();
     TransactionDetail transactionDetail = new TransactionDetail();
     transactionDetail.setSucceeded(isSucceeded);
-    walletRewards.add(new WalletReward(wallet, transactionDetail, 1L, 100, 10, rewardPeriod, 3));
-    walletRewards.add(new WalletReward(wallet4, transactionDetail, 4L, 200, 50, rewardPeriod, 2));
-    walletRewards.add(new WalletReward(wallet5, transactionDetail, 5L, 300, 40, rewardPeriod, 1));
+    walletRewards.add(new WalletReward(1, wallet, transactionDetail, 1L, 100, 10, rewardPeriod, 3));
+    walletRewards.add(new WalletReward(2, wallet4, transactionDetail, 4L, 200, 50, rewardPeriod, 2));
+    walletRewards.add(new WalletReward(3, wallet5, transactionDetail, 5L, 300, 40, rewardPeriod, 1));
     rewardReport.setRewards(walletRewards);
 
     return rewardReport;


### PR DESCRIPTION
Before this change, there were two issues:

The reward items list was not updated when the user reached 0 points after the reviewer canceled their achievements for the current period.

The reward items list was not updated at all after the reviewer canceled their achievements for a past unrewarded period.