### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/wallet-services/src/main/java/io/meeds/wallet/storage/WalletStorage.java
+++ b/wallet-services/src/main/java/io/meeds/wallet/storage/WalletStorage.java
@@ -239,8 +239,8 @@ public class WalletStorage {
     WalletPrivateKeyEntity privateKeyEntity = privateKeyDAO.findByWalletId(walletId);
     if (privateKeyEntity != null) {
       WalletEntity wallet = privateKeyEntity.getWallet();
-      privateKeyDAO.delete(privateKeyEntity);
       wallet.setPrivateKey(null);
+      privateKeyDAO.delete(privateKeyEntity);
       walletAccountDAO.update(wallet);
     }
   }


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations to not hit such a problem.