### PR TITLE
feat: Move reactive-streams to Meeds packaging

### DIFF
--- a/wallet-packaging/pom.xml
+++ b/wallet-packaging/pom.xml
@@ -57,6 +57,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/wallet-webapps/package-lock.json
+++ b/wallet-webapps/package-lock.json
@@ -5876,9 +5876,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
This change will move `reactive-streams` library as general dependency in Meeds package.