### PR TITLE
fix: Add an empty alt to the avatar of wallet - MEED-9967 - meeds-io/meeds#3854Stable 9967

### DIFF
--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsInternal.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsInternal.vue
@@ -6,7 +6,7 @@
           <img
             class="pr-2 pl-1"
             :src="`/wallet/images/meeds.svg`"
-            alt=" " 
+            alt="" 
             width="16">
           {{ $t('exoplatform.wallet.settings.meedsWallet') }}
         </div>

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsInternal.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsInternal.vue
@@ -6,7 +6,7 @@
           <img
             class="pr-2 pl-1"
             :src="`/wallet/images/meeds.svg`"
-            alt="Meeds" 
+            alt=" " 
             width="16">
           {{ $t('exoplatform.wallet.settings.meedsWallet') }}
         </div>

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
@@ -7,7 +7,7 @@
             <img
               class="pr-2 pl-1"
               :src="`/wallet/images/metamask.svg`"
-              alt="Metamask"
+              alt=" "
               width="18">
             <span></span>
             {{ $t('exoplatform.wallet.settings.useMetamask') }}

--- a/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
+++ b/wallet-webapps/src/main/webapp/vue-app/wallet-common/wallet-settings/components/WalletSettingsMetamask.vue
@@ -7,7 +7,7 @@
             <img
               class="pr-2 pl-1"
               :src="`/wallet/images/metamask.svg`"
-              alt=" "
+              alt=""
               width="18">
             <span></span>
             {{ $t('exoplatform.wallet.settings.useMetamask') }}


### PR DESCRIPTION
This commit set an empty alt for wallet avatars to make them decorative.