### PR TITLE
fix: Wallet Rewarding Page doesn't display Rewarding Periods - MEED-10047 - Meeds-io/meeds#3920

### DIFF
--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodSummaryDAO.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodSummaryDAO.java
@@ -25,5 +25,5 @@ import java.util.Optional;
 
 public interface RewardPeriodSummaryDAO extends JpaRepository<WalletRewardPeriodSummaryEntity, Long> {
 
-    Optional<WalletRewardPeriodSummaryEntity> findWalletRewardPeriodSummaryByRewardPeriodId(Long rewardPeriodId);
+    Optional<WalletRewardPeriodSummaryEntity> findTopByRewardPeriod_IdOrderByIdDesc(Long rewardPeriodId);
 }

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
@@ -286,7 +286,7 @@ public class WalletRewardReportStorage {
 
   public WalletRewardPeriodSummary findWalletRewardPeriodSummaryByRewardPeriodId(Long rewardPeriodId) {
     WalletRewardPeriodSummaryEntity walletRewardPeriodSummaryEntity =
-                                                                    rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(rewardPeriodId)
+                                                                    rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(rewardPeriodId)
                                                                                           .orElse(null);
     if (walletRewardPeriodSummaryEntity == null) {
       return null;
@@ -303,7 +303,7 @@ public class WalletRewardReportStorage {
   }
 
   private WalletRewardPeriodSummaryEntity createOrUpdateSummaryForRewardPeriod(WalletRewardPeriodSummary walletRewardPeriodSummary) {
-    return rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(walletRewardPeriodSummary.getPeriod().getId())
+    return rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(walletRewardPeriodSummary.getPeriod().getId())
             .map(existingSummary -> updateSummary(existingSummary, walletRewardPeriodSummary))
             .orElseGet(() -> createSummary(walletRewardPeriodSummary));
   }

--- a/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
@@ -260,4 +260,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <changeSet author="reward" id="1.0.0-19" dbms="oracle,postgresql,hsqldb">
     <createSequence sequenceName="SEQ_WALLET_REWARD_SUMMARY_ID" startValue="1"/>
   </changeSet>
+  <changeSet author="reward" id="1.0.0-20">
+    <addUniqueConstraint columnNames="REWARD_PERIOD_ID"
+                         constraintName="UQ_REWARD_PERIOD_SUMMARY_PERIOD"
+                         tableName="ADDONS_WALLET_REWARD_PERIOD_SUMMARY"/>
+  </changeSet>
 </databaseChangeLog>

--- a/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
@@ -260,9 +260,4 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <changeSet author="reward" id="1.0.0-19" dbms="oracle,postgresql,hsqldb">
     <createSequence sequenceName="SEQ_WALLET_REWARD_SUMMARY_ID" startValue="1"/>
   </changeSet>
-  <changeSet author="reward" id="1.0.0-20">
-    <addUniqueConstraint columnNames="REWARD_PERIOD_ID"
-                         constraintName="UQ_REWARD_PERIOD_SUMMARY_PERIOD"
-                         tableName="ADDONS_WALLET_REWARD_PERIOD_SUMMARY"/>
-  </changeSet>
 </databaseChangeLog>

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
@@ -140,7 +140,7 @@ class WalletRewardReportStorageTest {
       if (entity.getId() == null) {
         entity.setId(REWARD_PERIOD_SUMMARY_ID);
       }
-      when(rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(REWARD_PERIOD_ID)).thenReturn(Optional.of(entity));
+      when(rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(REWARD_PERIOD_ID)).thenReturn(Optional.of(entity));
       return entity;
     });
     doAnswer(invocation -> {


### PR DESCRIPTION
replace single-result query with findTopByRewardPeriod_IdOrderByIdDesc
to safely fetch the latest WalletRewardPeriodSummaryEntity.