### PR TITLE
fix: Wallet Rewarding Page doesn't display Rewarding Periods - MEED-10047 - Meeds-io/meeds#3920

### DIFF
--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodSummaryDAO.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodSummaryDAO.java
@@ -25,5 +25,5 @@ import java.util.Optional;
 
 public interface RewardPeriodSummaryDAO extends JpaRepository<WalletRewardPeriodSummaryEntity, Long> {
 
-    Optional<WalletRewardPeriodSummaryEntity> findWalletRewardPeriodSummaryByRewardPeriodId(Long rewardPeriodId);
+    Optional<WalletRewardPeriodSummaryEntity> findTopByRewardPeriod_IdOrderByIdDesc(Long rewardPeriodId);
 }

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
@@ -286,7 +286,7 @@ public class WalletRewardReportStorage {
 
   public WalletRewardPeriodSummary findWalletRewardPeriodSummaryByRewardPeriodId(Long rewardPeriodId) {
     WalletRewardPeriodSummaryEntity walletRewardPeriodSummaryEntity =
-                                                                    rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(rewardPeriodId)
+                                                                    rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(rewardPeriodId)
                                                                                           .orElse(null);
     if (walletRewardPeriodSummaryEntity == null) {
       return null;
@@ -303,7 +303,7 @@ public class WalletRewardReportStorage {
   }
 
   private WalletRewardPeriodSummaryEntity createOrUpdateSummaryForRewardPeriod(WalletRewardPeriodSummary walletRewardPeriodSummary) {
-    return rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(walletRewardPeriodSummary.getPeriod().getId())
+    return rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(walletRewardPeriodSummary.getPeriod().getId())
             .map(existingSummary -> updateSummary(existingSummary, walletRewardPeriodSummary))
             .orElseGet(() -> createSummary(walletRewardPeriodSummary));
   }

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
@@ -140,7 +140,7 @@ class WalletRewardReportStorageTest {
       if (entity.getId() == null) {
         entity.setId(REWARD_PERIOD_SUMMARY_ID);
       }
-      when(rewardPeriodSummaryDAO.findWalletRewardPeriodSummaryByRewardPeriodId(REWARD_PERIOD_ID)).thenReturn(Optional.of(entity));
+      when(rewardPeriodSummaryDAO.findTopByRewardPeriod_IdOrderByIdDesc(REWARD_PERIOD_ID)).thenReturn(Optional.of(entity));
       return entity;
     });
     doAnswer(invocation -> {


### PR DESCRIPTION
Replace single-result query with findTopByRewardPeriod_IdOrderByIdDesc to safely fetch the latest WalletRewardPeriodSummaryEntity