### PR TITLE
fix: Wallet Rewarding Page doesn't display Rewarding Periods - MEED-10047 - Meeds-io/meeds#3920 (#686)

### DIFF
--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodDAO.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/dao/RewardPeriodDAO.java
@@ -39,10 +39,7 @@ public interface RewardPeriodDAO extends JpaRepository<WalletRewardPeriodEntity,
       """)
   Page<WalletRewardPeriodEntity> findRewardPeriodsBetween(@Param("from") long from, @Param("to") long to, Pageable pageable);
 
-  @Query("""
-          SELECT rp FROM RewardPeriod rp WHERE rp.periodType = :periodType AND rp.startTime <= :periodTime AND rp.endTime > :periodTime
-      """)
-  WalletRewardPeriodEntity findRewardPeriodByTypeAndTime(@Param("periodType") RewardPeriodType periodType, @Param("periodTime") long periodTime);
+  WalletRewardPeriodEntity findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc(RewardPeriodType periodType, Long startTime, Long endTime);
 
   List<WalletRewardPeriodEntity> findWalletRewardPeriodEntitiesByStatus(RewardStatus status);
 

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/storage/WalletRewardReportStorage.java
@@ -85,16 +85,18 @@ public class WalletRewardReportStorage {
   public RewardReport getRewardReport(RewardPeriodType periodType, LocalDate date, ZoneId zoneId) {
     RewardPeriod period = periodType.getPeriodOfTime(date, zoneId);
     WalletRewardPeriodEntity rewardPeriodEntity =
-                                                rewardPeriodDAO.findRewardPeriodByTypeAndTime(periodType,
-                                                                                              period.getPeriodMedianDateInSeconds());
+                                                rewardPeriodDAO.findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc(periodType,
+                                                                                                                                                 period.getPeriodMedianDateInSeconds(),
+                                                                                                                                                 period.getPeriodMedianDateInSeconds());
     return getRewardReport(rewardPeriodEntity, zoneId);
   }
 
   public RewardPeriod getRewardPeriod(RewardPeriodType periodType, LocalDate date, ZoneId zoneId) {
     RewardPeriod period = periodType.getPeriodOfTime(date, zoneId);
     WalletRewardPeriodEntity rewardPeriodEntity =
-                                                rewardPeriodDAO.findRewardPeriodByTypeAndTime(periodType,
-                                                                                              period.getPeriodMedianDateInSeconds());
+                                                rewardPeriodDAO.findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc(periodType,
+                                                                                                                                                 period.getPeriodMedianDateInSeconds(),
+                                                                                                                                                 period.getPeriodMedianDateInSeconds());
     return toDTO(rewardPeriodEntity);
   }
 
@@ -149,8 +151,9 @@ public class WalletRewardReportStorage {
     }
     RewardPeriod period = rewardReport.getPeriod();
     WalletRewardPeriodEntity rewardPeriodEntity =
-                                                rewardPeriodDAO.findRewardPeriodByTypeAndTime(period.getRewardPeriodType(),
-                                                                                              period.getPeriodMedianDateInSeconds());
+                                                rewardPeriodDAO.findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc(period.getRewardPeriodType(),
+                                                                                                                                                 period.getPeriodMedianDateInSeconds(),
+                                                                                                                                                 period.getPeriodMedianDateInSeconds());
     if (rewardPeriodEntity == null) {
       rewardPeriodEntity = new WalletRewardPeriodEntity();
     } else if (rewardPeriodEntity.getStatus() == RewardStatus.SUCCESS) {

--- a/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
+++ b/wallet-reward-services/src/main/resources/db/changelog/reward-rdbms.db.changelog-1.0.0.xml
@@ -260,4 +260,22 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <changeSet author="reward" id="1.0.0-19" dbms="oracle,postgresql,hsqldb">
     <createSequence sequenceName="SEQ_WALLET_REWARD_SUMMARY_ID" startValue="1"/>
   </changeSet>
+
+  <changeSet author="reward" id="1.0.0-meeds-3920-clean-duplicates">
+    <sql>
+      DELETE
+      FROM ADDONS_WALLET_REWARD_PERIOD_SUMMARY
+      WHERE ID NOT IN (SELECT id
+                       FROM (SELECT MAX(ID) AS id
+                             FROM ADDONS_WALLET_REWARD_PERIOD_SUMMARY
+                             GROUP BY REWARD_PERIOD_ID) t);
+    </sql>
+  </changeSet>
+
+  <changeSet author="reward" id="1.0.0-meeds-3920-02">
+    <addUniqueConstraint columnNames="REWARD_PERIOD_ID"
+                         constraintName="UQ_REWARD_PERIOD_SUMMARY_PERIOD"
+                         tableName="ADDONS_WALLET_REWARD_PERIOD_SUMMARY"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/storage/WalletRewardReportStorageTest.java
@@ -124,7 +124,7 @@ class WalletRewardReportStorageTest {
       when(rewardPeriodDAO.findById(REWARD_PERIOD_ID)).thenReturn(Optional.of(entity));
       when(rewardPeriodDAO.findRewardPeriodsBetween(12125, 222125, PAGEABLE)).thenReturn(new PageImpl<>(List.of(entity)));
       when(rewardPeriodDAO.findAll(PAGEABLE)).thenReturn(new PageImpl<>(List.of(entity)));
-      when(rewardPeriodDAO.findRewardPeriodByTypeAndTime(any(RewardPeriodType.class), anyLong())).thenReturn(entity);
+      when(rewardPeriodDAO.findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc(any(RewardPeriodType.class), anyLong(), anyLong())).thenReturn(entity);
       when(rewardPeriodDAO.findWalletRewardPeriodEntitiesByStatus(any(RewardStatus.class))).thenReturn(List.of(entity));
       when(rewardPeriodDAO.count()).thenReturn(1L);
       return entity;


### PR DESCRIPTION
- Replace single-result query with findFirstByPeriodTypeAndStartTimeLessThanEqualAndEndTimeGreaterThanOrderByIdDesc to safely fetch the latest WalletRewardPeriodEntity

- Remove duplicate period summaries and add unique constraint