### PR TITLE
fix: Enhance Analytics Field Data Types - MEEDS-10142 - Meeds-io/meeds#3994 (#689)

### DIFF
--- a/wallet-api/src/test/java/io/meeds/wallet/statistic/StatisticUtilsTest.java
+++ b/wallet-api/src/test/java/io/meeds/wallet/statistic/StatisticUtilsTest.java
@@ -80,13 +80,13 @@ public class StatisticUtilsTest {
     assertEquals(StatisticStatus.valueOf(parameters.get(STATUS).toString().toUpperCase()), statisticData.getStatus());
     assertEquals(Long.parseLong(parameters.get(STATUS_CODE).toString()), statisticData.getErrorCode());
     assertEquals(0, statisticData.getUserId());
-    assertEquals(String.valueOf(toWallet.getTechnicalId()), statisticData.getParameters().get("toIdentityId"));
+    assertEquals(toWallet.getTechnicalId(), statisticData.getParameters().get("toIdentityId"));
     assertEquals(toWallet.getAddress(), statisticData.getParameters().get("toWalletAddress"));
-    assertEquals(String.valueOf(fromWallet.getTechnicalId()), statisticData.getParameters().get("fromIdentityId"));
+    assertEquals(fromWallet.getTechnicalId(), statisticData.getParameters().get("fromIdentityId"));
     assertEquals(fromWallet.getAddress(), statisticData.getParameters().get("fromWalletAddress"));
-    assertEquals(String.valueOf(byWallet.getTechnicalId()), statisticData.getParameters().get("byIdentityId"));
+    assertEquals(byWallet.getTechnicalId(), statisticData.getParameters().get("byIdentityId"));
     assertEquals(byWallet.getAddress(), statisticData.getParameters().get("byWalletAddress"));
-    assertEquals(String.valueOf(wallet.getTechnicalId()),
+    assertEquals(wallet.getTechnicalId(),
                  statisticData.getParameters().get(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID));
     assertEquals(wallet.getAddress(), statisticData.getParameters().get("walletAddress"));
   }

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListenerTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListenerTest.java
@@ -88,11 +88,11 @@ class RewardSucceedAnalyticsListenerTest {
       assertEquals("sendPeriodRewards", actualStatisticData.getOperation());
       assertEquals("UTC", actualStatisticData.getParameters().get("rewardPeriodTimeZone"));
       assertEquals("month", actualStatisticData.getParameters().get("rewardPeriodType"));
-      assertEquals("10", actualStatisticData.getParameters().get("rewardTransactionsCount"));
-      assertEquals("500.0", actualStatisticData.getParameters().get("rewardTokensSent"));
-      assertEquals("1000.0", actualStatisticData.getParameters().get("rewardTokensToSend"));
-      assertEquals("5", actualStatisticData.getParameters().get("rewardRecipientWalletCount"));
-      assertEquals("1", actualStatisticData.getParameters().get("rewardParticipantWalletCount"));
+      assertEquals(10l, actualStatisticData.getParameters().get("rewardTransactionsCount"));
+      assertEquals(500d, actualStatisticData.getParameters().get("rewardTokensSent"));
+      assertEquals(1000d, actualStatisticData.getParameters().get("rewardTokensToSend"));
+      assertEquals(5l, actualStatisticData.getParameters().get("rewardRecipientWalletCount"));
+      assertEquals(1, actualStatisticData.getParameters().get("rewardParticipantWalletCount"));
     }
   }
 }


### PR DESCRIPTION
Prior to this change, the `StatisticData` parameters of type Long were converted to String. After deleting the Numeric Auto Detection from Elasticsearch Mapping, the Long values will be stored as Long instead of String. Thus the data type in parameters isn't normalized anymore to use String and must be explicitly be of type String. This change will fix the used data type while adding a new `StatisticData`.

(cherry picked from commit 61968e8b320455aa5fc5b319c2963acfc25c92f7)