### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/wallet-api/src/main/java/io/meeds/wallet/statistic/StatisticUtils.java
+++ b/wallet-api/src/main/java/io/meeds/wallet/statistic/StatisticUtils.java
@@ -109,16 +109,16 @@ public class StatisticUtils {
 
         String prefix = key.replace("wallet", "").replace("Wallet", "");
         if (StringUtils.isBlank(prefix)) {
-          statisticData.addParameter(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID, wallet.getTechnicalId());
-          statisticData.addParameter("walletAddress", wallet.getAddress());
+          statisticData.addKeyword(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID, wallet.getTechnicalId());
+          statisticData.addKeyword("walletAddress", wallet.getAddress());
         } else {
           String entryKey = prefix + StringUtils.capitalize(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID);
-          statisticData.addParameter(entryKey, wallet.getTechnicalId());
-          statisticData.addParameter(prefix + "WalletAddress", wallet.getAddress());
+          statisticData.addKeyword(entryKey, wallet.getTechnicalId());
+          statisticData.addKeyword(prefix + "WalletAddress", wallet.getAddress());
         }
       }
     }
-    parameters.forEach(statisticData::addParameter);
+    parameters.forEach(statisticData::addKeyword);
     analyticsConsumer.accept(statisticData);
   }
 

--- a/wallet-api/src/test/java/io/meeds/wallet/statistic/StatisticUtilsTest.java
+++ b/wallet-api/src/test/java/io/meeds/wallet/statistic/StatisticUtilsTest.java
@@ -80,13 +80,13 @@ public class StatisticUtilsTest {
     assertEquals(StatisticStatus.valueOf(parameters.get(STATUS).toString().toUpperCase()), statisticData.getStatus());
     assertEquals(Long.parseLong(parameters.get(STATUS_CODE).toString()), statisticData.getErrorCode());
     assertEquals(0, statisticData.getUserId());
-    assertEquals(toWallet.getTechnicalId(), statisticData.getParameters().get("toIdentityId"));
+    assertEquals(String.valueOf(toWallet.getTechnicalId()), statisticData.getParameters().get("toIdentityId"));
     assertEquals(toWallet.getAddress(), statisticData.getParameters().get("toWalletAddress"));
-    assertEquals(fromWallet.getTechnicalId(), statisticData.getParameters().get("fromIdentityId"));
+    assertEquals(String.valueOf(fromWallet.getTechnicalId()), statisticData.getParameters().get("fromIdentityId"));
     assertEquals(fromWallet.getAddress(), statisticData.getParameters().get("fromWalletAddress"));
-    assertEquals(byWallet.getTechnicalId(), statisticData.getParameters().get("byIdentityId"));
+    assertEquals(String.valueOf(byWallet.getTechnicalId()), statisticData.getParameters().get("byIdentityId"));
     assertEquals(byWallet.getAddress(), statisticData.getParameters().get("byWalletAddress"));
-    assertEquals(wallet.getTechnicalId(),
+    assertEquals(String.valueOf(wallet.getTechnicalId()),
                  statisticData.getParameters().get(AnalyticsUtils.FIELD_SOCIAL_IDENTITY_ID));
     assertEquals(wallet.getAddress(), statisticData.getParameters().get("walletAddress"));
   }

--- a/wallet-reward-services/src/main/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListener.java
+++ b/wallet-reward-services/src/main/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListener.java
@@ -63,17 +63,17 @@ public class RewardSucceedAnalyticsListener extends Listener<RewardReport, Objec
     statisticData.setModule("wallet");
     statisticData.setSubModule("reward");
     statisticData.setOperation("sendPeriodRewards");
-    statisticData.addParameter("rewardPeriodStartDate",
-                               Date.from(Instant.ofEpochSecond(rewardReport.getPeriod().getStartDateInSeconds())));
-    statisticData.addParameter("rewardPeriodEndDate",
-                               Date.from(Instant.ofEpochSecond(rewardReport.getPeriod().getEndDateInSeconds())));
-    statisticData.addParameter("rewardPeriodTimeZone", rewardReport.getPeriod().getTimeZone());
-    statisticData.addParameter("rewardPeriodType", rewardReport.getPeriod().getRewardPeriodType().name().toLowerCase());
-    statisticData.addParameter("rewardTransactionsCount", rewardReport.getSuccessTransactionCount());
-    statisticData.addParameter("rewardTokensSent", rewardReport.getTokensSent());
-    statisticData.addParameter("rewardTokensToSend", rewardReport.getTokensToSend());
-    statisticData.addParameter("rewardRecipientWalletCount", rewardReport.getValidRewardCount());
-    statisticData.addParameter("rewardParticipantWalletCount", rewardReport.getRewards().size());
+    statisticData.addDate("rewardPeriodStartDate",
+                          Date.from(Instant.ofEpochSecond(rewardReport.getPeriod().getStartDateInSeconds())));
+    statisticData.addDate("rewardPeriodEndDate",
+                          Date.from(Instant.ofEpochSecond(rewardReport.getPeriod().getEndDateInSeconds())));
+    statisticData.addKeyword("rewardPeriodTimeZone", rewardReport.getPeriod().getTimeZone());
+    statisticData.addKeyword("rewardPeriodType", rewardReport.getPeriod().getRewardPeriodType().name().toLowerCase());
+    statisticData.addLong("rewardTransactionsCount", rewardReport.getSuccessTransactionCount());
+    statisticData.addDouble("rewardTokensSent", rewardReport.getTokensSent());
+    statisticData.addDouble("rewardTokensToSend", rewardReport.getTokensToSend());
+    statisticData.addLong("rewardRecipientWalletCount", rewardReport.getValidRewardCount());
+    statisticData.addLong("rewardParticipantWalletCount", rewardReport.getRewards().size());
 
     AnalyticsUtils.addStatisticData(statisticData);
   }

--- a/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListenerTest.java
+++ b/wallet-reward-services/src/test/java/io/meeds/wallet/reward/listener/RewardSucceedAnalyticsListenerTest.java
@@ -92,7 +92,7 @@ class RewardSucceedAnalyticsListenerTest {
       assertEquals(500d, actualStatisticData.getParameters().get("rewardTokensSent"));
       assertEquals(1000d, actualStatisticData.getParameters().get("rewardTokensToSend"));
       assertEquals(5l, actualStatisticData.getParameters().get("rewardRecipientWalletCount"));
-      assertEquals(1, actualStatisticData.getParameters().get("rewardParticipantWalletCount"));
+      assertEquals(1l, actualStatisticData.getParameters().get("rewardParticipantWalletCount"));
     }
   }
 }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.